### PR TITLE
Handle disconnects during TCX transactions

### DIFF
--- a/specialized_turbo/__init__.py
+++ b/specialized_turbo/__init__.py
@@ -124,6 +124,7 @@ from .transport import (
     BLETraceEvent as BLETraceEvent,
     TCXNotificationTransport as TCXNotificationTransport,
     TCXRequestTimeoutError as TCXRequestTimeoutError,
+    TCXTransportDisconnectedError as TCXTransportDisconnectedError,
 )
 from .protocol import (
     parse_tcx_message as parse_tcx_message,
@@ -238,6 +239,7 @@ __all__ = [
     "BLETraceEvent",
     "TCXNotificationTransport",
     "TCXRequestTimeoutError",
+    "TCXTransportDisconnectedError",
     # Coordinator helpers
     "TCX_POLL_PARAMS",
     "parse_notification",

--- a/specialized_turbo/connection.py
+++ b/specialized_turbo/connection.py
@@ -190,16 +190,21 @@ class SpecializedConnection:
         # Create protocol session
         if self._generation == BLEProfile.TCX:
             self._session = TCXSession()
-            self._tcx_transport = TCXNotificationTransport(
+            transport = TCXNotificationTransport(
                 self._client,
                 session=self._session,
                 trace_callback=self._trace_callback,
             )
-            await self._tcx_transport.subscribe_for_identification()
-            session = await identify_tcx(self._tcx_transport)
+            self._tcx_transport = transport
+            await transport.subscribe_for_identification()
+            session = await identify_tcx(transport)
+            if not self._client.is_connected:
+                raise RuntimeError(
+                    f"Disconnected from {self._address} during identification"
+                )
             self._session = session
-            self._tcx_transport.session = session
-            await self._tcx_transport.subscribe_for_realtime()
+            transport.session = session
+            await transport.subscribe_for_realtime()
         else:
             self._session = TCU1Session()
 
@@ -243,14 +248,15 @@ class SpecializedConnection:
             raise RuntimeError("Not connected")
 
         if self._generation == BLEProfile.TCX:
-            if self._tcx_transport is None:
+            transport = self._tcx_transport
+            if transport is None:
                 raise RuntimeError("TCX transport is not initialized")
-            self._tcx_transport.add_listener(callback)
+            transport.add_listener(callback)
             self._telemetry_callback = callback
             try:
-                await self._tcx_transport.set_realtime_enabled(True)
+                await transport.set_realtime_enabled(True)
             except Exception:
-                self._tcx_transport.remove_listener(callback)
+                transport.remove_listener(callback)
                 self._telemetry_callback = None
                 raise
         else:
@@ -262,14 +268,13 @@ class SpecializedConnection:
         """Stop receiving telemetry notifications."""
         if self._client and self._notification_started:
             if self._generation == BLEProfile.TCX:
-                if self._tcx_transport is not None:
+                transport = self._tcx_transport
+                if transport is not None:
                     try:
-                        await self._tcx_transport.set_realtime_enabled(False)
+                        await transport.set_realtime_enabled(False)
                     finally:
                         if self._telemetry_callback is not None:
-                            self._tcx_transport.remove_listener(
-                                self._telemetry_callback
-                            )
+                            transport.remove_listener(self._telemetry_callback)
                         self._telemetry_callback = None
             else:
                 await self._client.stop_notify(self._char_notify)
@@ -402,6 +407,9 @@ class SpecializedConnection:
     def _on_disconnect(self, client: BleakClient) -> None:
         logger.warning("Disconnected from bike!")
         self._notification_started = False
+        transport = self._tcx_transport
         self._tcx_transport = None
+        if transport is not None:
+            transport.mark_disconnected()
         if self._disconnect_cb:
             self._disconnect_cb(client)

--- a/specialized_turbo/coordinator_helpers.py
+++ b/specialized_turbo/coordinator_helpers.py
@@ -30,7 +30,7 @@ from .protocol import (
     ParsedMessage,
 )
 from .session import ProtocolSession, TCXSession
-from .transport import TCXNotificationTransport
+from .transport import TCXNotificationTransport, TCXTransportDisconnectedError
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +125,8 @@ async def poll_tcx(
                 continue
             snapshot.update_from_message(msg)
             updated = True
+        except TCXTransportDisconnectedError:
+            raise
         except Exception:  # noqa: BLE001
             logger.debug("Failed to poll TCX param %d", int(param), exc_info=True)
     return updated
@@ -172,6 +174,8 @@ async def identify_tcx(
 
             if param == BikeParameter.BATTERY1_FIRMWARE:
                 key_response = inner
+    except TCXTransportDisconnectedError:
+        raise
     except Exception:  # noqa: BLE001
         logger.warning(
             "TCX identification handshake failed, using unencrypted session",

--- a/specialized_turbo/transport.py
+++ b/specialized_turbo/transport.py
@@ -57,6 +57,10 @@ class TCXRequestTimeoutError(TimeoutError):
         self.timeout = timeout
 
 
+class TCXTransportDisconnectedError(ConnectionError):
+    """Raised when the BLE link closes during a TCX transaction."""
+
+
 @dataclass(slots=True)
 class _PendingRequest:
     param_id: int
@@ -83,6 +87,7 @@ class TCXNotificationTransport:
         self._subscribed: set[BLEServiceID] = set()
         self._pending: _PendingRequest | None = None
         self._request_lock = asyncio.Lock()
+        self._disconnected = False
 
     @property
     def session(self) -> TCXSession:
@@ -103,8 +108,20 @@ class TCXNotificationTransport:
         if callback in self._listeners:
             self._listeners.remove(callback)
 
+    def mark_disconnected(self) -> None:
+        """Fail any in-flight request after the BLE link closes."""
+        self._disconnected = True
+        pending = self._pending
+        if pending is not None and not pending.future.done():
+            pending.future.set_exception(
+                TCXTransportDisconnectedError(
+                    "Bike disconnected during TCX transaction"
+                )
+            )
+
     async def subscribe(self, service_id: BLEServiceID) -> None:
         """Enable notifications for one TCX service."""
+        self._raise_if_disconnected()
         if service_id in self._subscribed:
             return
 
@@ -186,6 +203,7 @@ class TCXNotificationTransport:
         data: bytes | bytearray,
     ) -> None:
         """Write an already-framed packet without response."""
+        self._raise_if_disconnected()
         characteristic = get_service_characteristics(BLEProfile.TCX, service_id).write
         packet = bytes(data)
         self._emit_trace("tx", service_id, characteristic, packet)
@@ -204,8 +222,10 @@ class TCXNotificationTransport:
         timeout: float | None,
     ) -> bytes:
         request_timeout = self._request_timeout if timeout is None else timeout
+        self._raise_if_disconnected()
 
         async with self._request_lock:
+            self._raise_if_disconnected()
             future = asyncio.get_running_loop().create_future()
             self._pending = _PendingRequest(param_id, service_id, future)
             try:
@@ -259,6 +279,12 @@ class TCXNotificationTransport:
             param_id, _reason = parse_nak_packet(payload)
             return param_id
         return decode_parameter_id(payload)
+
+    def _raise_if_disconnected(self) -> None:
+        if self._disconnected:
+            raise TCXTransportDisconnectedError(
+                "Bike disconnected during TCX transaction"
+            )
 
     def _emit_trace(
         self,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -18,7 +18,10 @@ from specialized_turbo.protocol import (
     get_service_characteristics,
 )
 from specialized_turbo.telemetry import TelemetryMonitor
-from specialized_turbo.transport import NotificationCallback
+from specialized_turbo.transport import (
+    NotificationCallback,
+    TCXTransportDisconnectedError,
+)
 
 
 @dataclass
@@ -43,6 +46,7 @@ class _FakeBleakClient:
         self.writes: list[tuple[str, bytes, bool | None]] = []
         self.reads: list[str] = []
         self.read_response = bytes.fromhex("000c31")
+        self.disconnect_on_param: int | None = None
 
     async def connect(self) -> None:
         self.is_connected = True
@@ -77,6 +81,14 @@ class _FakeBleakClient:
         packet = bytes(data)
         self.writes.append((characteristic, packet, response))
 
+        if len(packet) == 20:
+            param_id = int.from_bytes(unpack_tcx(packet)[:2], "big")
+            if param_id == self.disconnect_on_param:
+                self.is_connected = False
+                if self.disconnected_callback is not None:
+                    self.disconnected_callback(self)
+                return
+
         request_service = get_service_characteristics(
             BLEProfile.TCX,
             BLEServiceID.REQUEST,
@@ -84,7 +96,6 @@ class _FakeBleakClient:
         if characteristic != request_service.write or len(packet) != 20:
             return
 
-        param_id = int.from_bytes(unpack_tcx(packet)[:2], "big")
         if param_id == 14:
             reply = pack_tcx(bytes.fromhex("f8ff000e05"))
         elif param_id == 26:
@@ -101,6 +112,20 @@ class _FakeBleakClient:
             _FakeCharacteristic(uuid),
         )
         callback(characteristic, bytearray(data))
+
+
+class _DisconnectingBleakClient(_FakeBleakClient):
+    def __init__(
+        self,
+        address: object,
+        *,
+        disconnected_callback: Callable[[Any], None] | None = None,
+    ) -> None:
+        super().__init__(
+            address,
+            disconnected_callback=disconnected_callback,
+        )
+        self.disconnect_on_param = 300
 
 
 @pytest.fixture
@@ -148,6 +173,23 @@ async def test_tcx_connect_identifies_without_gatt_reads(
 
 
 @pytest.mark.asyncio
+async def test_disconnect_during_identification_fails_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    monkeypatch.setattr(
+        connection_module,
+        "BleakClient",
+        _DisconnectingBleakClient,
+    )
+
+    with pytest.raises(TCXTransportDisconnectedError, match="disconnected"):
+        await connection.connect()
+
+    assert not connection.is_connected
+
+
+@pytest.mark.asyncio
 async def test_tcx_read_and_stream_control_use_notifications(
     fake_bleak: type[_FakeBleakClient],
 ) -> None:
@@ -187,6 +229,29 @@ async def test_tcx_read_and_stream_control_use_notifications(
     assert disable_response is False
 
     await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_unsubscribe_does_not_race_transport_cleanup(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
+
+    def notification(
+        _sender: BleakGATTCharacteristic,
+        _data: bytearray,
+    ) -> None:
+        pass
+
+    await connection.subscribe_notifications(notification)
+    client.disconnect_on_param = 346
+
+    await connection.unsubscribe_notifications()
+
+    assert not connection.is_connected
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast
@@ -24,6 +25,7 @@ from specialized_turbo.transport import (
     NotificationCallback,
     TCXNotificationTransport,
     TCXRequestTimeoutError,
+    TCXTransportDisconnectedError,
     TraceCallback,
 )
 
@@ -195,6 +197,21 @@ async def test_request_times_out_and_clears_pending_state() -> None:
     client.on_write = respond
     response = await transport.request_parameter(26)
     assert parse_tcx_message(response).converted_value == 49
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fails_pending_request_immediately() -> None:
+    client = _FakeClient()
+    transport = _transport(client, request_timeout=60)
+    request = asyncio.create_task(transport.request_parameter(26))
+    await asyncio.sleep(0)
+
+    transport.mark_disconnected()
+
+    with pytest.raises(TCXTransportDisconnectedError, match="disconnected"):
+        await request
+    with pytest.raises(TCXTransportDisconnectedError, match="disconnected"):
+        await transport.request_parameter(26)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fail in-flight TCX requests immediately when the bike disconnects, leaving the connection retryable.