### PR TITLE
Add secret-safe bike key model

### DIFF
--- a/specialized_turbo/keystore/__init__.py
+++ b/specialized_turbo/keystore/__init__.py
@@ -1,0 +1,28 @@
+"""
+Offline, secret-safe bike encryption key support.
+
+This subpackage is intentionally isolated from the rest of
+``specialized_turbo``: it is not imported by the top-level package
+``__init__.py`` and has no effect on BLE connection, CLI, or protocol
+behavior. Import directly from ``specialized_turbo.keystore`` to use it.
+
+It contains only :class:`BikeEncryptionKey` (a validated, secret-safe
+wrapper around AES-128 key material) and its typed exceptions. There is
+no account/backend HTTP client here, and no optional dependency is
+required -- everything in this package imports cleanly with only the
+base ``specialized-turbo`` install.
+"""
+
+from __future__ import annotations
+
+from .exceptions import (
+    InvalidEncryptionKeyError as InvalidEncryptionKeyError,
+    KeystoreError as KeystoreError,
+)
+from .models import BikeEncryptionKey as BikeEncryptionKey
+
+__all__ = [
+    "BikeEncryptionKey",
+    "KeystoreError",
+    "InvalidEncryptionKeyError",
+]

--- a/specialized_turbo/keystore/exceptions.py
+++ b/specialized_turbo/keystore/exceptions.py
@@ -1,0 +1,16 @@
+"""
+Typed exceptions for the ``specialized_turbo.keystore`` package.
+
+These exceptions are safe to log: none of them carry key material in
+their message or attributes.
+"""
+
+from __future__ import annotations
+
+
+class KeystoreError(Exception):
+    """Base class for all errors raised by :mod:`specialized_turbo.keystore`."""
+
+
+class InvalidEncryptionKeyError(KeystoreError):
+    """Raised when key material fails validation (wrong format/length)."""

--- a/specialized_turbo/keystore/models.py
+++ b/specialized_turbo/keystore/models.py
@@ -1,0 +1,122 @@
+"""
+Secret-safe container for a bike's AES-128 encryption key.
+
+``BikeEncryptionKey`` only *validates and wraps* key material that the
+caller already possesses -- it has no BLE or network capability of its
+own and cannot retrieve a key on your behalf. Wrapped (``wrapped_base64``)
+key material must come from an external, authorized source, such as:
+
+- the bike's own ``BTEncryptionInfo``, captured during a prior BLE
+  identification handshake (see :func:`specialized_turbo.encryption.derive_key`
+  and :mod:`specialized_turbo.protocol`), or
+- an account-linked keystore service, accessed out-of-band through the
+  official Specialized app/API.
+
+This package intentionally does not implement any such retrieval itself:
+there is no backend HTTP client here, and BLE cannot be used to *look
+up* a key that was not exchanged during an active connection's own
+identification flow. Supplying valid key material remains the caller's
+responsibility.
+"""
+
+from __future__ import annotations
+
+from ..encryption import derive_key
+from .exceptions import InvalidEncryptionKeyError
+
+_WRAPPED_KEY_LENGTH = 64
+_RAW_KEY_LENGTH = 16
+
+
+class BikeEncryptionKey:
+    """
+    A validated 16-byte AES-128 bike encryption key.
+
+    Secret-safe: the raw key material is never exposed through
+    ``repr()``, ``str()``, equality checks, or exception messages.
+    Access the raw bytes explicitly via the ``raw`` property only when
+    handing them to :mod:`specialized_turbo.encryption`.
+
+    Construct with exactly one of:
+
+    - ``wrapped_base64``: the official 64-character base64-encoded key,
+      as advertised by the bike's ``BTEncryptionInfo``. Derived via
+      :func:`specialized_turbo.encryption.derive_key`. This value must
+      come from an external, authorized source -- this class cannot
+      retrieve it over BLE itself.
+    - ``raw``: an already-derived 16-byte key, as ``bytes``/``bytearray``
+      or a 32-character hex string.
+    """
+
+    __slots__ = ("_key",)
+
+    def __init__(
+        self,
+        *,
+        wrapped_base64: str | None = None,
+        raw: bytes | bytearray | str | None = None,
+    ) -> None:
+        if (wrapped_base64 is None) == (raw is None):
+            raise ValueError("Exactly one of wrapped_base64 or raw must be provided")
+
+        if wrapped_base64 is not None:
+            key = self._derive_from_wrapped(wrapped_base64)
+        else:
+            assert raw is not None
+            key = self._decode_raw(raw)
+
+        if len(key) != _RAW_KEY_LENGTH:
+            raise InvalidEncryptionKeyError(
+                f"Encryption key must be {_RAW_KEY_LENGTH} bytes, got {len(key)}"
+            )
+        self._key = bytes(key)
+
+    @staticmethod
+    def _derive_from_wrapped(wrapped_base64: str) -> bytes:
+        if len(wrapped_base64) != _WRAPPED_KEY_LENGTH:
+            raise InvalidEncryptionKeyError(
+                f"Wrapped key must be {_WRAPPED_KEY_LENGTH} characters, "
+                f"got {len(wrapped_base64)}"
+            )
+        try:
+            return derive_key(wrapped_base64)
+        except Exception as exc:
+            # Deliberately drop the original exception (and its message,
+            # which may echo back fragments of the invalid input) --
+            # only the exception type is safe to surface.
+            raise InvalidEncryptionKeyError(
+                f"Failed to derive key from wrapped base64 value ({type(exc).__name__})"
+            ) from None
+
+    @staticmethod
+    def _decode_raw(raw: bytes | bytearray | str) -> bytes:
+        if isinstance(raw, str):
+            try:
+                return bytes.fromhex(raw)
+            except ValueError:
+                raise InvalidEncryptionKeyError(
+                    "raw key string must be valid hexadecimal"
+                ) from None
+        if isinstance(raw, (bytes, bytearray)):
+            return bytes(raw)
+        raise InvalidEncryptionKeyError(
+            f"raw key must be bytes, bytearray, or a hex string, got {type(raw).__name__}"
+        )
+
+    @property
+    def raw(self) -> bytes:
+        """The raw 16-byte AES-128 key. Handle with care -- do not log."""
+        return self._key
+
+    def __repr__(self) -> str:
+        return "BikeEncryptionKey(<redacted>)"
+
+    __str__ = __repr__
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BikeEncryptionKey):
+            return NotImplemented
+        return self._key == other._key
+
+    def __hash__(self) -> int:
+        return hash(self._key)

--- a/tests/test_keystore_models.py
+++ b/tests/test_keystore_models.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for specialized_turbo.keystore.models — BikeEncryptionKey.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from specialized_turbo.keystore.exceptions import InvalidEncryptionKeyError
+from specialized_turbo.keystore.models import BikeEncryptionKey
+
+FINAL_KEY = bytes(range(16))
+INTERMEDIATE_KEY = bytes(range(100, 116))
+
+
+def make_wrapped_key(
+    final_key: bytes = FINAL_KEY, intermediate_key: bytes = INTERMEDIATE_KEY
+) -> str:
+    """Build a valid 64-char wrapped base64 key that derive_key() can decode."""
+    hex_ascii = final_key.hex().encode("ascii")
+    iv = b"\x00" * 16
+    cipher = Cipher(algorithms.AES(intermediate_key), modes.CTR(iv))
+    encryptor = cipher.encryptor()
+    encrypted_rest = encryptor.update(hex_ascii) + encryptor.finalize()
+    raw = intermediate_key + encrypted_rest
+    return base64.b64encode(raw).decode("ascii")
+
+
+class TestConstructionFromWrapped:
+    def test_valid_wrapped_key(self):
+        wrapped = make_wrapped_key()
+        key = BikeEncryptionKey(wrapped_base64=wrapped)
+        assert key.raw == FINAL_KEY
+
+    def test_wrong_length_wrapped_key(self):
+        with pytest.raises(InvalidEncryptionKeyError, match="64 characters"):
+            BikeEncryptionKey(wrapped_base64="short")
+
+    def test_invalid_base64_wrapped_key(self):
+        # Correct length (64 chars) but not valid base64 content.
+        with pytest.raises(InvalidEncryptionKeyError, match="Failed to derive key"):
+            BikeEncryptionKey(wrapped_base64="!" * 64)
+
+    def test_derivation_failure_message_has_no_key_content(self):
+        bogus = "!" * 64
+        with pytest.raises(InvalidEncryptionKeyError) as exc_info:
+            BikeEncryptionKey(wrapped_base64=bogus)
+        assert bogus not in str(exc_info.value)
+
+
+class TestConstructionFromRaw:
+    def test_raw_bytes(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        assert key.raw == FINAL_KEY
+
+    def test_raw_bytearray(self):
+        key = BikeEncryptionKey(raw=bytearray(FINAL_KEY))
+        assert key.raw == FINAL_KEY
+
+    def test_raw_hex_string(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY.hex())
+        assert key.raw == FINAL_KEY
+
+    def test_raw_wrong_length(self):
+        with pytest.raises(InvalidEncryptionKeyError, match="16 bytes"):
+            BikeEncryptionKey(raw=b"\x00" * 8)
+
+    def test_raw_invalid_hex(self):
+        with pytest.raises(InvalidEncryptionKeyError, match="hexadecimal"):
+            BikeEncryptionKey(raw="not-hex-zz")
+
+    def test_raw_wrong_type(self):
+        bad_raw: Any = 12345
+        with pytest.raises(InvalidEncryptionKeyError, match="must be bytes"):
+            BikeEncryptionKey(raw=bad_raw)
+
+
+class TestConstructionArgumentValidation:
+    def test_neither_argument_raises(self):
+        with pytest.raises(ValueError, match="Exactly one of"):
+            BikeEncryptionKey()
+
+    def test_both_arguments_raises(self):
+        with pytest.raises(ValueError, match="Exactly one of"):
+            BikeEncryptionKey(wrapped_base64=make_wrapped_key(), raw=FINAL_KEY)
+
+
+class TestSecretSafety:
+    def test_repr_is_redacted(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        assert FINAL_KEY.hex() not in repr(key)
+        assert "redacted" in repr(key)
+
+    def test_str_is_redacted(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        assert FINAL_KEY.hex() not in str(key)
+        assert "redacted" in str(key)
+
+    def test_fstring_does_not_leak(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        assert FINAL_KEY.hex() not in f"{key}"
+
+    def test_log_redaction(self, caplog: pytest.LogCaptureFixture):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        with caplog.at_level(logging.DEBUG):
+            logging.getLogger(__name__).info("got key %s", key)
+        assert FINAL_KEY.hex() not in caplog.text
+
+    def test_no_dict_leakage(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        with pytest.raises(TypeError):
+            vars(key)
+
+
+class TestEquality:
+    def test_equal_keys(self):
+        assert BikeEncryptionKey(raw=FINAL_KEY) == BikeEncryptionKey(
+            raw=FINAL_KEY.hex()
+        )
+
+    def test_different_keys_not_equal(self):
+        other = bytes(reversed(FINAL_KEY))
+        assert BikeEncryptionKey(raw=FINAL_KEY) != BikeEncryptionKey(raw=other)
+
+    def test_not_equal_to_other_type(self):
+        assert BikeEncryptionKey(raw=FINAL_KEY) != FINAL_KEY
+
+    def test_hashable(self):
+        key = BikeEncryptionKey(raw=FINAL_KEY)
+        assert hash(key) == hash(BikeEncryptionKey(raw=FINAL_KEY))

--- a/tests/test_keystore_offline.py
+++ b/tests/test_keystore_offline.py
@@ -1,0 +1,66 @@
+"""
+Tests that specialized_turbo.keystore is fully offline: no HTTP client,
+no aiohttp dependency, and no import-time reliance on network libraries.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import specialized_turbo.keystore as ks
+
+
+class TestPackageSurface:
+    def test_exports_only_key_model_and_exceptions(self):
+        assert set(ks.__all__) == {
+            "BikeEncryptionKey",
+            "KeystoreError",
+            "InvalidEncryptionKeyError",
+        }
+
+    def test_no_http_client_symbols(self):
+        for name in ("KeystoreClient", "DEFAULT_BASE_URL", "client"):
+            assert not hasattr(ks, name)
+
+    def test_invalid_encryption_key_error_is_keystore_error(self):
+        assert issubclass(ks.InvalidEncryptionKeyError, ks.KeystoreError)
+
+
+class TestNoAiohttpDependency:
+    def test_importing_keystore_does_not_import_aiohttp(self):
+        script = (
+            "import sys\n"
+            "import specialized_turbo.keystore\n"
+            "assert 'aiohttp' not in sys.modules, sorted(sys.modules)\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_keystore_imports_without_aiohttp_installed(self):
+        """Even if aiohttp is entirely absent, the keystore package must
+        still import cleanly -- it has no dependency on it at all."""
+        script = (
+            "import sys\n"
+            "sys.modules['aiohttp'] = None\n"
+            "import specialized_turbo.keystore as ks\n"
+            "assert ks.BikeEncryptionKey is not None\n"
+            "assert ks.KeystoreError is not None\n"
+            "assert ks.InvalidEncryptionKeyError is not None\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout


### PR DESCRIPTION
Add offline validation and redaction for externally supplied TCX AES keys.