### PR TITLE
Parse Specialized BLE bike info

### DIFF
--- a/specialized_turbo/_hmi_compat_data.py
+++ b/specialized_turbo/_hmi_compat_data.py
@@ -1,0 +1,39 @@
+"""
+Compact HMI hardware-compatibility table.
+
+This is an original re-expression, as plain Python data, of the *factual*
+HMI-hardware-version-to-category groupings observed in the Specialized
+app's ``assets/hmi_config/hmi_config.json`` (its ``hw_compatibility``
+section only). It is not a copy of that file: the JSON asset itself is
+proprietary app content and is intentionally **not** vendored or shipped
+here, byte-identical or otherwise. Only the underlying facts needed for
+``HmiType`` lookup -- which HW-version strings identify each HMI hardware
+family -- are represented, in a format specific to this library.
+
+``hw_replacement_exceptions`` (a separate section of that JSON, used by
+the app for hardware-replacement/warranty logic) is not consulted by
+``getHmiType``/``getBikeInfo`` and is deliberately excluded here.
+
+Provenance: HW-version groupings observed via reverse engineering of
+``libturbo-core.so`` (Specialized app 1.66.0) -- see the BLE
+advertisement -> BikeInfo report for the full evidence. Refresh this table
+if Specialized ships a new HMI hardware revision.
+"""
+
+from __future__ import annotations
+
+# category name -> "X.Y.Z" HW-version strings that identify it.
+# "TCUArterytek" is intentionally excluded from HmiType lookup (the native
+# getHmiType() skips this category and returns UNKNOWN for those HW
+# strings), but is retained here for completeness/documentation.
+HW_COMPATIBILITY: dict[str, tuple[str, ...]] = {
+    "TCU": ("A.1.0", "A.1.2"),
+    "TCUArterytek": ("A.5.0", "A.5.1"),
+    "TCDw": ("A.2.0",),
+    "TCU2": ("B.4.3", "B.4.4", "A.4.4", "A.4.5", "A.4.6"),
+    "TCDw2": ("B.3.2", "B.3.3", "A.3.3", "A.3.4", "A.3.5", "A.3.6"),
+    "T3": ("A.6.0", "A.6.1", "A.6.2", "A.6.3", "A.6.4"),
+    "H3": ("A.8.1", "A.8.2", "A.8.3", "A.8.4", "A.8.5"),
+    "C4": ("A.7.0",),
+    "T4": ("A.D.0",),
+}

--- a/specialized_turbo/bike_info.py
+++ b/specialized_turbo/bike_info.py
@@ -1,0 +1,402 @@
+"""
+BLE advertisement -> ``BikeInfo`` parsing.
+
+A Python port of ``TurboConnectCore::getBikeInfo``/``isBike``, reverse
+engineered from ``libturbo-core.so`` (Specialized app 1.66.0). This is a
+*pre-connect* parse: it only ever looks at the advertised name and BLE
+manufacturer data, never at a GATT connection.
+
+Key findings this module implements (see the BLE advertisement -> BikeInfo
+report for full evidence):
+
+- The Nordic (``0x0059``) manufacturer-data payload is a **structured
+  10-byte record** for TCX2+ bikes, carrying the HMI serial, HMI hardware
+  version, bike type, and system state -- it is not unrelated/opaque data.
+- ``hmiType`` is derived from the HMI hardware-version string (built from
+  Nordic bytes 4-6, e.g. ``"B.3.3"``) looked up in a hardware-compatibility
+  table (:mod:`specialized_turbo._hmi_compat_data`), not from the
+  advertisement bytes directly and not from the device name.
+- The Apple iBeacon frame (``0x004C``) is **detection magic only**;
+  ``getBikeInfo``/``isBike`` never read its bytes for fields. If a Nordic
+  10-byte record is also present, it is used; otherwise the result is
+  marked incomplete rather than guessing fields from Apple data.
+- The AES key is never present in the advertisement -- it is provisioned
+  out-of-band by the backend -- so it has no field here.
+- Simplo (``0x020D``) advertisements are TCU1 (legacy, unencrypted) bikes.
+
+``BLEProfile`` (which GATT UUID family a bike speaks -- TCU1/Simplo vs.
+TCX/Nordic) and ``TCXGeneration`` (the fine-grained TCX2/TCX3/TCX4
+identification-protocol generation) are two different, independent axes.
+A Nordic advertisement is always ``BLEProfile.TCX`` -- even when its
+HMI-hardware family (``HmiType``) happens to be one of the legacy
+``TCU1``/``TCDw`` families with no TCX2+ generation -- because the
+company ID (and thus which GATT characteristics/UUIDs the bike will
+speak) is Nordic. ``TCXGeneration`` is therefore only ever set when the
+looked-up ``HmiType`` maps to one of TCU2/TCDw2 (TCX2), T3/H3 (TCX3), or
+C4/T4 (TCX4); it stays ``None`` for any other (including unknown/legacy)
+hardware.
+
+This module's ``is_bike`` is a *strict*, native-faithful reimplementation
+of ``isBike`` and intentionally does **not** match every advertisement
+the existing, more permissive :func:`specialized_turbo.protocol.
+detect_generation`/:func:`specialized_turbo.protocol.
+is_specialized_advertisement` helpers do (e.g. a bike whose *only*
+discovery signal is the ``TURBOHMI2017`` magic inside an Apple iBeacon
+frame, with a name that doesn't contain ``"SPECIALIZED"``, is not
+``is_bike`` here -- native ``isBike`` never reads company ``0x004C``
+either). Production **discovery** (deciding whether to attempt a BLE
+connection at all) should keep using the existing, broader
+``detect_generation``/``is_specialized_advertisement`` superset, not this
+module's ``is_bike``. To help bridge the two, :func:`parse_bike_info`
+still best-efforts a coarse ``ble_profile`` via ``detect_generation`` for
+any advertisement it can't fully or partially decode -- so ``ble_profile``
+can be non-``None`` even when ``is_bike`` is ``False``.
+
+This module does not change ``detect_generation``/
+``is_specialized_advertisement`` themselves, and does not open or manage
+a BLE connection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+from . import _hmi_compat_data as _hmi_compat
+from .protocol import (
+    NORDIC_COMPANY_ID,
+    SIMPLO_COMPANY_ID,
+    BLEProfile,
+    detect_generation,
+)
+from .wire_profiles import TCXGeneration
+
+# ---------------------------------------------------------------------------
+# Enums (DWARF-confirmed: HmiType, BikeType, SystemState, ProtocolEncryptionMethod)
+# ---------------------------------------------------------------------------
+
+
+class HmiType(IntEnum):
+    """HMI hardware family, looked up from the HMI hardware-version string."""
+
+    UNKNOWN = 0
+    TCU1 = 1
+    TCDw = 2
+    TCU2 = 3
+    TCDw2 = 4
+    T3 = 5
+    H3 = 6
+    C4 = 7
+    T4 = 8
+
+
+class BikeType(IntEnum):
+    """Bike model/platform, as advertised in the Nordic payload's byte 8."""
+
+    PROTOTYPE = 0
+    TURBO = 1
+    LEVO1 = 2
+    VADO = 3
+    PLW = 4
+    LEVO2 = 5
+    COMO2 = 6
+    PLW2 = 7
+    APLW2 = 8
+    PLUTO = 9
+    APLUTO = 10
+    APLUTOPLUS = 11
+    PLUTO2 = 12
+
+
+class BikeSystemState(IntEnum):
+    """Bike system state, as advertised in the Nordic payload's byte 9.
+
+    Named distinctly from :class:`specialized_turbo.models.SystemState`
+    (post-connection telemetry state) to avoid confusion: this enum only
+    describes the coarse on/off/reset/locked state visible pre-connect.
+    """
+
+    OFF = 0
+    ON = 1
+    RESET = 2
+    LOCKED = 3
+
+
+class ProtocolEncryptionMethod(IntEnum):
+    """Wire-level encryption method implied by the advertisement."""
+
+    NONE = 0
+    AES_CTR = 1
+
+
+# ---------------------------------------------------------------------------
+# Internal lookup tables
+# ---------------------------------------------------------------------------
+
+# getHmiType()'s category-check order. "TCUArterytek" is intentionally
+# excluded: getHmiType() skips that category and falls through to UNKNOWN.
+_HMI_CATEGORY_TO_TYPE: dict[str, HmiType] = {
+    "TCU": HmiType.TCU1,
+    "TCDw": HmiType.TCDw,
+    "TCU2": HmiType.TCU2,
+    "TCDw2": HmiType.TCDw2,
+    "T3": HmiType.T3,
+    "H3": HmiType.H3,
+    "C4": HmiType.C4,
+    "T4": HmiType.T4,
+}
+
+# knownVersionsNoTcx1(): union of HW-version strings for TCU2-and-newer
+# categories, used by isBike()'s HW-version-membership detection branch.
+_KNOWN_NO_TCX1: frozenset[str] = frozenset(
+    hw
+    for category in ("TCU2", "TCDw2", "T3", "H3", "C4", "T4")
+    for hw in _hmi_compat.HW_COMPATIBILITY[category]
+)
+
+# getBikeTypeAsString(): used to build the composite bikeName display
+# string, including the "?<value>" fallback for unrecognized byte values.
+_BIKE_TYPE_NAMES: dict[int, str] = {int(bt): bt.name for bt in BikeType}
+
+# TCU1 (Simplo) payload byte-0 model code -> display name.
+_TCU1_MODEL_NAMES: dict[int, str] = {1: "TURBO", 2: "LEVO"}
+
+_MAGIC = b"TURBOHMI2017"
+
+
+def _hmi_hw_string(three_bytes: bytes) -> str:
+    """Build the "X.Y.Z" HMI hardware-version string from 3 raw bytes.
+
+    Matches the native implementation exactly: each byte is decoded as a
+    single ASCII/Latin-1 character with no validation. A non-ASCII byte
+    still yields a (non-matching) string deterministically -- it simply
+    fails every hardware-compatibility lookup below and results in
+    :attr:`HmiType.UNKNOWN`, exactly as the native parser would.
+    """
+    return f"{chr(three_bytes[0])}.{chr(three_bytes[1])}.{chr(three_bytes[2])}"
+
+
+def _hmi_type_for_hw(hmi_hw: str) -> HmiType:
+    for category, hmi_type in _HMI_CATEGORY_TO_TYPE.items():
+        if hmi_hw in _hmi_compat.HW_COMPATIBILITY[category]:
+            return hmi_type
+    return HmiType.UNKNOWN
+
+
+def _tcx_generation_for_hmi_type(hmi_type: HmiType) -> TCXGeneration | None:
+    """isTCX2/isTCX3/isTCX4 classification.
+
+    Returns ``None`` for anything that isn't a TCX2/TCX3/TCX4 HMI-hardware
+    family -- including :attr:`HmiType.UNKNOWN` and the legacy
+    :attr:`HmiType.TCU1`/:attr:`HmiType.TCDw` families. This is *only* the
+    fine-grained protocol generation; it says nothing about which
+    ``BLEProfile`` the advertisement uses (see module docstring).
+    """
+    if hmi_type in (HmiType.TCU2, HmiType.TCDw2):
+        return TCXGeneration.TCX2
+    if hmi_type in (HmiType.T3, HmiType.H3):
+        return TCXGeneration.TCX3
+    if hmi_type in (HmiType.C4, HmiType.T4):
+        return TCXGeneration.TCX4
+    return None
+
+
+def _is_bike(name: str, manufacturer_data: dict[int, bytes]) -> bool:
+    """Reimplementation of ``TurboConnectCore::isBike``.
+
+    True if the name contains the literal, uppercase ``"SPECIALIZED"``
+    (case-sensitive -- the native memchr-based scan matches that exact
+    byte sequence, not a case-folded one; a `name` shorter than 11
+    characters can never satisfy this by construction), a Simplo (TCU1)
+    entry is present, or a Nordic entry is present that either carries the
+    ``TURBOHMI2017`` magic (>=12 bytes) or is a 10-byte record whose
+    HW-version string belongs to a TCU2-or-newer category. Company
+    ``0x004C`` (Apple) is never consulted, matching the native
+    implementation.
+    """
+    if "SPECIALIZED" in name:
+        return True
+    if SIMPLO_COMPANY_ID in manufacturer_data:
+        return True
+    nordic = manufacturer_data.get(NORDIC_COMPANY_ID)
+    if nordic is not None:
+        if len(nordic) >= 12 and _MAGIC in nordic:
+            return True
+        if len(nordic) == 10 and _hmi_hw_string(nordic[4:7]) in _KNOWN_NO_TCX1:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# BikeInfo
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BikeInfo:
+    """Fields derivable from a BLE advertisement, before any GATT connection.
+
+    Mirrors ``TurboConnectCore::getBikeInfo``'s output. Many upstream
+    ``BikeInfo`` fields (protocol version, firmware versions, serials, the
+    AES key) are never populated from the advertisement alone and have no
+    equivalent here -- they require the encrypted post-connect
+    identification handshake.
+
+    ``complete`` distinguishes a fully-decoded record (TCU1, or a Nordic
+    10-byte structured record) from a detection-only result: ``is_bike``
+    can be ``True`` while ``complete`` is ``False`` (e.g. a bike detected
+    only by name or by the Nordic ``TURBOHMI2017`` magic, with no Nordic
+    10-byte payload present). Callers must not treat an incomplete result's
+    unset fields as "unknown bike" -- they mean "not yet derivable from
+    this advertisement".
+
+    ``ble_profile`` and ``tcx_generation`` are two independent axes:
+
+    - ``ble_profile`` is which GATT UUID family the bike speaks (mirrors
+      :func:`specialized_turbo.protocol.detect_generation`'s return type).
+      It is set precisely (``BLEProfile.TCU1``/``BLEProfile.TCX``) whenever
+      ``complete`` is ``True``. When ``complete`` is ``False``, it is
+      instead a *coarse best-effort hint* from the existing, more
+      permissive ``detect_generation`` heuristic -- so it can be non-
+      ``None`` even when ``is_bike`` is ``False`` (e.g. an advertisement
+      whose only signal is the Apple iBeacon ``TURBOHMI2017`` magic).
+      ``is_bike`` itself is never inferred from this hint; production
+      *discovery* should keep using ``detect_generation``/
+      ``is_specialized_advertisement`` directly, not this field.
+    - ``tcx_generation`` is the fine-grained TCX2/TCX3/TCX4 identification
+      generation, set **only** for a complete Nordic 10-byte record whose
+      looked-up ``hmi_type`` is one of TCU2/TCDw2 (TCX2), T3/H3 (TCX3), or
+      C4/T4 (TCX4). It is ``None`` for TCU1-profile bikes, for any other
+      (including unknown or legacy TCU1/TCDw-family) Nordic hardware, and
+      whenever ``complete`` is ``False``. A Nordic record with unrecognized
+      HMI hardware therefore still reports ``ble_profile=BLEProfile.TCX``
+      -- it is unambiguously a Nordic/TCX advertisement -- while
+      ``tcx_generation`` stays ``None``.
+
+    ``encryption_method`` is ``None`` whenever ``complete`` is ``False`` --
+    "unknown" must never be confused with "no encryption". It is only ever
+    :attr:`ProtocolEncryptionMethod.NONE` for a complete TCU1 record, or
+    :attr:`ProtocolEncryptionMethod.AES_CTR` for a complete Nordic 10-byte
+    record (hardcoded for every such record, matching the native
+    implementation).
+    """
+
+    name: str
+    bike_name: str
+    is_bike: bool
+    complete: bool
+    hmi_serial: str | None = None
+    hmi_hardware_version: str | None = None
+    hmi_type: HmiType | None = None
+    ble_profile: BLEProfile | None = None
+    tcx_generation: TCXGeneration | None = None
+    encryption_method: ProtocolEncryptionMethod | None = None
+    bike_type: BikeType | None = None
+    system_state: BikeSystemState | None = None
+
+
+def parse_bike_info(name: str, manufacturer_data: dict[int, bytes]) -> BikeInfo:
+    """Parse a BLE advertisement (name + manufacturer data) into a ``BikeInfo``.
+
+    - Simplo (``0x020D``) advertisements (with no Nordic entry) yield a
+      complete TCU1 record: ``hmi_type=HmiType.TCU1``,
+      ``ble_profile=BLEProfile.TCU1``, ``tcx_generation=None``,
+      ``encryption_method=ProtocolEncryptionMethod.NONE``.
+    - A Nordic (``0x0059``) entry with an exactly-10-byte payload yields a
+      complete TCX record: HMI serial/hardware version, bike type, system
+      state, ``hmi_type`` (looked up from the hardware-version string,
+      falling back to :attr:`HmiType.UNKNOWN` for unrecognized hardware),
+      ``ble_profile=BLEProfile.TCX`` (always, regardless of ``hmi_type``),
+      ``tcx_generation`` set only for a TCX2/TCX3/TCX4 ``hmi_type`` (``None``
+      otherwise), and ``encryption_method=ProtocolEncryptionMethod.AES_CTR``
+      (hardcoded for every such record, matching the native implementation).
+    - Any other advertisement recognized as a bike (by name, Simplo
+      presence, or a non-10-byte Nordic ``TURBOHMI2017`` payload -- this
+      includes advertisements where only the Apple iBeacon frame carries
+      discovery magic) yields an incomplete, name-only result:
+      ``is_bike=True``, ``complete=False``, ``encryption_method=None``,
+      ``tcx_generation=None``, and a best-effort ``ble_profile`` from the
+      existing ``detect_generation`` heuristic (``None`` if it can't
+      determine one either).
+    - Anything else yields ``is_bike=False``, ``complete=False``, with the
+      same best-effort ``ble_profile`` handling as above -- ``is_bike``
+      being ``False`` does not imply ``ble_profile`` is ``None``.
+
+    Unrecognized ``bike_type``/``system_state`` byte values are reported as
+    ``None`` (there is no verified "unknown" member for those enums); an
+    unrecognized HMI hardware version is reported as
+    :attr:`HmiType.UNKNOWN` (the native enum's own definition for this
+    case). No exception is raised for malformed/short/non-ASCII input --
+    the native parser degrades the same way.
+    """
+    if not _is_bike(name, manufacturer_data):
+        return BikeInfo(
+            name=name,
+            bike_name=name,
+            is_bike=False,
+            complete=False,
+            ble_profile=detect_generation(manufacturer_data),
+        )
+
+    if (
+        SIMPLO_COMPANY_ID in manufacturer_data
+        and NORDIC_COMPANY_ID not in manufacturer_data
+    ):
+        payload = manufacturer_data[SIMPLO_COMPANY_ID]
+        model = _TCU1_MODEL_NAMES.get(payload[0], "") if payload else ""
+        bike_name = f"{model} {name}".strip()
+        return BikeInfo(
+            name=name,
+            bike_name=bike_name,
+            is_bike=True,
+            complete=True,
+            hmi_type=HmiType.TCU1,
+            ble_profile=BLEProfile.TCU1,
+            tcx_generation=None,
+            encryption_method=ProtocolEncryptionMethod.NONE,
+        )
+
+    nordic = manufacturer_data.get(NORDIC_COMPANY_ID)
+    if nordic is not None and len(nordic) == 10:
+        hmi_serial = str(int.from_bytes(nordic[0:4], "little"))
+        hmi_hw = _hmi_hw_string(nordic[4:7])
+        hmi_type = _hmi_type_for_hw(hmi_hw)
+        bike_type_value = nordic[8]
+        system_state_value = nordic[9]
+        try:
+            bike_type = BikeType(bike_type_value)
+        except ValueError:
+            bike_type = None
+        try:
+            system_state = BikeSystemState(system_state_value)
+        except ValueError:
+            system_state = None
+        bike_type_label = _BIKE_TYPE_NAMES.get(bike_type_value, f"?{bike_type_value}")
+        return BikeInfo(
+            name=name,
+            bike_name=f"{bike_type_label} {name}",
+            is_bike=True,
+            complete=True,
+            hmi_serial=hmi_serial,
+            hmi_hardware_version=hmi_hw,
+            hmi_type=hmi_type,
+            ble_profile=BLEProfile.TCX,
+            tcx_generation=_tcx_generation_for_hmi_type(hmi_type),
+            encryption_method=ProtocolEncryptionMethod.AES_CTR,
+            bike_type=bike_type,
+            system_state=system_state,
+        )
+
+    # Detected (by name, Simplo presence, or Nordic TURBOHMI2017 magic) but
+    # no structured 10-byte record available -- e.g. Apple-only
+    # advertisements, or a Nordic payload that isn't exactly 10 bytes.
+    # ble_profile is a best-effort hint from the existing, more permissive
+    # detect_generation heuristic; encryption_method/tcx_generation stay
+    # None (unknown, not "none").
+    return BikeInfo(
+        name=name,
+        bike_name=name,
+        is_bike=True,
+        complete=False,
+        ble_profile=detect_generation(manufacturer_data),
+    )

--- a/tests/test_bike_info.py
+++ b/tests/test_bike_info.py
@@ -1,0 +1,544 @@
+"""
+Unit tests for bike_info.py -- BLE advertisement -> BikeInfo parsing.
+
+Fixture vectors (including the real ``ha-specialized-turbo#9`` bike) are
+transcribed from the verified ``advertisement_fixtures.json`` companion
+artifact for the BLE advertisement -> BikeInfo report (reverse engineered
+from ``libturbo-core.so``, Specialized app 1.66.0).
+"""
+
+import pytest
+
+from specialized_turbo.bike_info import (
+    BikeInfo,
+    BikeSystemState,
+    BikeType,
+    HmiType,
+    ProtocolEncryptionMethod,
+    parse_bike_info,
+)
+from specialized_turbo.protocol import BLEProfile
+from specialized_turbo.wire_profiles import TCXGeneration
+
+
+def _mfr_data(raw: dict[str, str]) -> dict[int, bytes]:
+    """Convert a fixture's {"<decimal company id>": "<hex payload>"} map."""
+    return {
+        int(company_id): bytes.fromhex(hex_payload)
+        for company_id, hex_payload in raw.items()
+    }
+
+
+class TestIssue9RealVector:
+    """ha-specialized-turbo#9 -- the real "Vado 3.0"/2022 bike dump.
+
+    Confirms the bike remains classified TCX2/AES_CTR after splitting the
+    old combined ``generation`` field into ``ble_profile``/``tcx_generation``.
+    """
+
+    NAME = "WSBC001057439S"
+    MFR = _mfr_data(
+        {
+            "76": "0215545552424f484d4932303137010000005fe033060a",
+            "89": "dac8c404423333330601",
+        }
+    )
+
+    def test_parses_full_record(self):
+        info = parse_bike_info(self.NAME, self.MFR)
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.bike_name == "COMO2 WSBC001057439S"
+        assert info.bike_type is BikeType.COMO2
+        assert info.hmi_type is HmiType.TCDw2
+        assert info.system_state is BikeSystemState.ON
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+        assert info.hmi_serial == "80005338"
+        assert info.hmi_hardware_version == "B.3.3"
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation is TCXGeneration.TCX2
+
+
+# Each entry: (id, name, mfr_data, expected fields dict).
+#
+# All of these are complete Nordic (0x0059) records, so ble_profile is
+# always BLEProfile.TCX -- regardless of hmi_type -- and tcx_generation is
+# only set for a TCX2/TCX3/TCX4 hmi_type (None for the legacy TCU1/TCDw
+# families and for UNKNOWN).
+_SYNTHETIC_HMI_TYPE_VECTORS = [
+    (
+        "synthetic_TCU_A.1.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413130300101"},
+        dict(
+            bike_name="TURBO SPECIALIZED-TEST",
+            bike_type=BikeType.TURBO,
+            hmi_type=HmiType.TCU1,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.1.0",
+            tcx_generation=None,
+        ),
+    ),
+    (
+        "synthetic_TCUArterytek_A.5.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413530300101"},
+        dict(
+            bike_name="TURBO SPECIALIZED-TEST",
+            bike_type=BikeType.TURBO,
+            hmi_type=HmiType.UNKNOWN,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.5.0",
+            tcx_generation=None,
+        ),
+    ),
+    (
+        "synthetic_TCDw_A.2.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413230300201"},
+        dict(
+            bike_name="LEVO1 SPECIALIZED-TEST",
+            bike_type=BikeType.LEVO1,
+            hmi_type=HmiType.TCDw,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.2.0",
+            tcx_generation=None,
+        ),
+    ),
+    (
+        "synthetic_TCU2_B.4.3",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001423433330601"},
+        dict(
+            bike_name="COMO2 SPECIALIZED-TEST",
+            bike_type=BikeType.COMO2,
+            hmi_type=HmiType.TCU2,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="B.4.3",
+            tcx_generation=TCXGeneration.TCX2,
+        ),
+    ),
+    (
+        "synthetic_TCDw2_B.3.2",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001423332320601"},
+        dict(
+            bike_name="COMO2 SPECIALIZED-TEST",
+            bike_type=BikeType.COMO2,
+            hmi_type=HmiType.TCDw2,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="B.3.2",
+            tcx_generation=TCXGeneration.TCX2,
+        ),
+    ),
+    (
+        "synthetic_T3_A.6.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413630300301"},
+        dict(
+            bike_name="VADO SPECIALIZED-TEST",
+            bike_type=BikeType.VADO,
+            hmi_type=HmiType.T3,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.6.0",
+            tcx_generation=TCXGeneration.TCX3,
+        ),
+    ),
+    (
+        "synthetic_H3_A.8.1",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413831310301"},
+        dict(
+            bike_name="VADO SPECIALIZED-TEST",
+            bike_type=BikeType.VADO,
+            hmi_type=HmiType.H3,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.8.1",
+            tcx_generation=TCXGeneration.TCX3,
+        ),
+    ),
+    (
+        "synthetic_C4_A.7.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001413730300501"},
+        dict(
+            bike_name="LEVO2 SPECIALIZED-TEST",
+            bike_type=BikeType.LEVO2,
+            hmi_type=HmiType.C4,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.7.0",
+            tcx_generation=TCXGeneration.TCX4,
+        ),
+    ),
+    (
+        "synthetic_T4_A.D.0",
+        "SPECIALIZED-TEST",
+        {"89": "2a000001414430300501"},
+        dict(
+            bike_name="LEVO2 SPECIALIZED-TEST",
+            bike_type=BikeType.LEVO2,
+            hmi_type=HmiType.T4,
+            system_state=BikeSystemState.ON,
+            hmi_serial="16777258",
+            hmi_hardware_version="A.D.0",
+            tcx_generation=TCXGeneration.TCX4,
+        ),
+    ),
+]
+
+
+class TestAllHmiTypes:
+    """Every HmiType (incl. UNKNOWN via TCUArterytek) from the artifact fixtures."""
+
+    @pytest.mark.parametrize(
+        "vector_id,name,mfr_raw,expected",
+        _SYNTHETIC_HMI_TYPE_VECTORS,
+        ids=[v[0] for v in _SYNTHETIC_HMI_TYPE_VECTORS],
+    )
+    def test_synthetic_vector(self, vector_id, name, mfr_raw, expected):
+        info = parse_bike_info(name, _mfr_data(mfr_raw))
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.bike_name == expected["bike_name"]
+        assert info.bike_type is expected["bike_type"]
+        assert info.hmi_type is expected["hmi_type"]
+        assert info.system_state is expected["system_state"]
+        assert info.hmi_serial == expected["hmi_serial"]
+        assert info.hmi_hardware_version == expected["hmi_hardware_version"]
+        # Every complete Nordic record is unambiguously BLEProfile.TCX,
+        # regardless of the looked-up hmi_type (even legacy TCU1/TCDw or
+        # UNKNOWN hardware) -- it's the company ID, not the HMI hardware
+        # family, that determines the BLE profile.
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation == expected["tcx_generation"]
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+
+    def test_all_hmi_type_members_are_reachable(self):
+        """Every HmiType member (except UNKNOWN, covered separately) appears
+        in the synthetic vectors above -- guards against a member being
+        added to the enum without a corresponding fixture."""
+        covered = {v[3]["hmi_type"] for v in _SYNTHETIC_HMI_TYPE_VECTORS}
+        assert covered == set(HmiType)
+
+    def test_unknown_and_legacy_hardware_have_tcx_profile_but_no_generation(self):
+        """Unknown or legacy (TCU1/TCDw-family) HMI hardware inside a
+        Nordic record still yields ble_profile=TCX (it's unambiguously a
+        Nordic advertisement) but tcx_generation stays None (there is no
+        TCX2/3/4 generation for it)."""
+        no_generation_ids = {
+            "synthetic_TCU_A.1.0",
+            "synthetic_TCUArterytek_A.5.0",
+            "synthetic_TCDw_A.2.0",
+        }
+        for vector_id, name, mfr_raw, expected in _SYNTHETIC_HMI_TYPE_VECTORS:
+            if vector_id not in no_generation_ids:
+                continue
+            info = parse_bike_info(name, _mfr_data(mfr_raw))
+            assert info.ble_profile is BLEProfile.TCX, vector_id
+            assert info.tcx_generation is None, vector_id
+
+
+class TestTCU1:
+    def test_tcu1_simplo_levo(self):
+        info = parse_bike_info(
+            "SPECIALIZED LEVO", _mfr_data({"525": "02000000000000000000"})
+        )
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.bike_name == "LEVO SPECIALIZED LEVO"
+        assert info.hmi_type is HmiType.TCU1
+        assert info.ble_profile is BLEProfile.TCU1
+        assert info.tcx_generation is None
+        assert info.encryption_method is ProtocolEncryptionMethod.NONE
+        assert info.bike_type is None
+        assert info.system_state is None
+        assert info.hmi_serial is None
+        assert info.hmi_hardware_version is None
+
+    def test_tcu1_unknown_model_byte(self):
+        """An unrecognized Simplo byte-0 model code degrades to an empty
+        model name rather than raising."""
+        info = parse_bike_info("SPECIALIZED BIKE", _mfr_data({"525": "ff"}))
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.bike_name == "SPECIALIZED BIKE"
+        assert info.hmi_type is HmiType.TCU1
+        assert info.ble_profile is BLEProfile.TCU1
+        assert info.encryption_method is ProtocolEncryptionMethod.NONE
+
+    def test_tcu1_empty_payload(self):
+        """An empty Simplo payload does not raise (no byte-0 to read)."""
+        info = parse_bike_info("SPECIALIZED BIKE", _mfr_data({"525": ""}))
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.bike_name == "SPECIALIZED BIKE"
+        assert info.ble_profile is BLEProfile.TCU1
+        assert info.tcx_generation is None
+        assert info.encryption_method is ProtocolEncryptionMethod.NONE
+
+    def test_nordic_present_takes_priority_over_simplo(self):
+        """If both Simplo and a valid Nordic 10-byte record are present,
+        the Nordic record wins (per the report: "if Nordic structured
+        data is also present, use it")."""
+        info = parse_bike_info(
+            "WSBC001057439S",
+            _mfr_data({"525": "02000000000000000000", "89": "dac8c404423333330601"}),
+        )
+        assert info.hmi_type is HmiType.TCDw2
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation is TCXGeneration.TCX2
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+
+
+class TestNotABike:
+    def test_not_a_bike(self):
+        info = parse_bike_info("Some Headphones", _mfr_data({"76": "0215aabbccdd"}))
+        assert info.is_bike is False
+        assert info.complete is False
+        assert info.bike_name == "Some Headphones"
+        assert info.bike_type is None
+        assert info.hmi_type is None
+        assert info.system_state is None
+        assert info.ble_profile is None
+        assert info.tcx_generation is None
+        # Incomplete: encryption method is unknown, never NONE.
+        assert info.encryption_method is None
+
+    def test_empty_advertisement(self):
+        info = parse_bike_info("Random Device", {})
+        assert info.is_bike is False
+        assert info.complete is False
+        assert info.ble_profile is None
+        assert info.encryption_method is None
+
+    def test_lowercase_specialized_name_is_not_detected(self):
+        """isBike matches the literal uppercase "SPECIALIZED" byte
+        sequence; the native scan is case-sensitive, so a differently
+        cased name must not trigger name-based detection."""
+        info = parse_bike_info("specialized-test", {})
+        assert info.is_bike is False
+        assert info.complete is False
+
+    def test_mixed_case_specialized_name_is_not_detected(self):
+        info = parse_bike_info("Specialized-Test", {})
+        assert info.is_bike is False
+
+    def test_name_shorter_than_specialized_is_not_detected(self):
+        """A name shorter than len("SPECIALIZED") == 11 can never satisfy
+        the substring check."""
+        info = parse_bike_info("SPECIALIZE", {})
+        assert info.is_bike is False
+
+
+class TestAppleDiscoveryOnly:
+    """Apple 0x004C is discovery-only; without Nordic structured data (or a
+    "SPECIALIZED" name) no HMI/bike fields may be invented from it.
+
+    ``is_bike`` stays strictly native-faithful (native ``isBike`` never
+    reads company ``0x004C``), but ``ble_profile`` is still populated as a
+    coarse hint via the existing, more permissive ``detect_generation``
+    whenever it can determine one -- which it can here, since the Apple
+    iBeacon frame does carry the ``TURBOHMI2017`` magic that
+    ``detect_generation`` (unlike this module's ``is_bike``) checks for in
+    *any* manufacturer-data payload. This is exactly why production
+    discovery must keep using the existing
+    ``detect_generation``/``is_specialized_advertisement`` superset rather
+    than this module's ``is_bike``.
+    """
+
+    def test_apple_ibeacon_only_no_nordic(self):
+        info = parse_bike_info(
+            "WSBC000000000S",
+            _mfr_data({"76": "0215545552424f484d4932303137010000005fe033060a"}),
+        )
+        assert info.is_bike is False
+        assert info.complete is False
+        assert info.bike_name == "WSBC000000000S"
+        assert info.hmi_type is None
+        assert info.bike_type is None
+        assert info.hmi_serial is None
+        assert info.hmi_hardware_version is None
+        assert info.tcx_generation is None
+        assert info.encryption_method is None
+        # Coarse hint still available despite is_bike being False: the
+        # existing detect_generation() superset does check Apple payloads
+        # for the TURBOHMI2017 magic.
+        assert info.ble_profile is BLEProfile.TCX
+
+    def test_apple_ibeacon_with_specialized_name_is_incomplete(self):
+        """Name-based detection still fires, but no structured Nordic
+        record means the result stays incomplete (no invented fields)."""
+        info = parse_bike_info(
+            "SPECIALIZED-TEST",
+            _mfr_data({"76": "0215545552424f484d4932303137010000005fe033060a"}),
+        )
+        assert info.is_bike is True
+        assert info.complete is False
+        assert info.bike_name == "SPECIALIZED-TEST"
+        assert info.hmi_type is None
+        assert info.bike_type is None
+        assert info.tcx_generation is None
+        assert info.encryption_method is None
+        assert info.ble_profile is BLEProfile.TCX
+
+    def test_apple_and_nordic_together_uses_nordic(self):
+        """When Nordic structured data coexists with the Apple frame, the
+        Nordic record is used (matches the real issue-#9 vector)."""
+        info = parse_bike_info(
+            "WSBC001057439S",
+            _mfr_data(
+                {
+                    "76": "0215545552424f484d4932303137010000005fe033060a",
+                    "89": "dac8c404423333330601",
+                }
+            ),
+        )
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.hmi_type is HmiType.TCDw2
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation is TCXGeneration.TCX2
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+
+
+class TestMalformedNordicPayloads:
+    def test_short_nordic_payload_is_incomplete_not_error(self):
+        """A Nordic payload that's too short for the 10-byte record (and
+        without the TURBOHMI2017 magic) yields no detection at all."""
+        info = parse_bike_info("Random Device", _mfr_data({"89": "dac8c404"}))
+        assert info.is_bike is False
+        assert info.complete is False
+        assert info.ble_profile is None
+        assert info.encryption_method is None
+
+    def test_short_nordic_payload_with_specialized_name(self):
+        """Same short payload, but the name alone makes it a detected,
+        incomplete bike -- fields are not guessed from a short payload."""
+        info = parse_bike_info("SPECIALIZED-TEST", _mfr_data({"89": "dac8c404"}))
+        assert info.is_bike is True
+        assert info.complete is False
+        assert info.hmi_type is None
+        assert info.hmi_serial is None
+        # detect_generation() also can't find the magic in this short,
+        # non-conforming payload, so the coarse hint is unavailable too.
+        assert info.ble_profile is None
+        assert info.encryption_method is None
+
+    def test_oversized_nordic_payload_with_magic(self):
+        """>=12 bytes carrying TURBOHMI2017 is detected as a bike (isBike),
+        but getBikeInfo only extracts fields from the exact 10-byte form,
+        so the result stays incomplete -- though the coarse ble_profile
+        hint from detect_generation is still available (same magic)."""
+        payload = b"\x00" * 4 + b"TURBOHMI2017"
+        info = parse_bike_info("WSBC999999999S", {0x0059: payload})
+        assert info.is_bike is True
+        assert info.complete is False
+        assert info.hmi_type is None
+        assert info.bike_type is None
+        assert info.tcx_generation is None
+        assert info.encryption_method is None
+        assert info.ble_profile is BLEProfile.TCX
+
+    def test_eleven_byte_nordic_payload_without_magic_is_undetected(self):
+        payload = bytes(11)
+        info = parse_bike_info("Random Device", {0x0059: payload})
+        assert info.is_bike is False
+        assert info.complete is False
+        assert info.ble_profile is None
+
+    def test_non_ascii_hardware_bytes_yield_unknown_hmi_type(self):
+        """Non-ASCII HW-version bytes don't raise -- they simply never
+        match a hardware-compatibility entry, exactly like the native
+        parser, and fall through to HmiType.UNKNOWN. The record is still a
+        complete Nordic parse (ble_profile=TCX, encryption_method=AES_CTR)
+        -- only the fine-grained tcx_generation is unavailable."""
+        # bytes[4:7] = 0xff,0xfe,0xfd (non-ASCII); bytes[8]=0x01 (TURBO),
+        # bytes[9]=0x01 (ON). Not auto-detected by HW membership or name,
+        # so route through the TURBOHMI2017-magic-detection path instead.
+        payload = bytes.fromhex("dac8c404") + bytes(
+            [0xFF, 0xFE, 0xFD, 0x00, 0x01, 0x01]
+        )
+        assert len(payload) == 10
+        info = parse_bike_info("SPECIALIZED-TEST", {0x0059: payload})
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.hmi_type is HmiType.UNKNOWN
+        assert info.hmi_hardware_version == f"{chr(0xFF)}.{chr(0xFE)}.{chr(0xFD)}"
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation is None
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+        assert info.bike_type is BikeType.TURBO
+        assert info.system_state is BikeSystemState.ON
+
+    def test_unknown_bike_type_and_system_state_bytes(self):
+        """Byte values with no defined BikeType/SystemState enum member
+        degrade to None rather than raising, while the display name still
+        falls back to a "?<value>" label (matching the native
+        getBikeTypeAsString behavior for unrecognized values). ble_profile
+        and tcx_generation are unaffected by unrelated unknown bytes."""
+        # hw bytes 4:7 = "B.3.3" (TCDw2, a known-no-tcx1 HW string, so this
+        # advertisement is detected as a bike purely by HW membership).
+        payload = bytes.fromhex("dac8c404") + b"B33" + b"3" + bytes([0x63, 0x63])
+        assert len(payload) == 10
+        info = parse_bike_info("WSBC001057439S", {0x0059: payload})
+        assert info.is_bike is True
+        assert info.complete is True
+        assert info.hmi_type is HmiType.TCDw2
+        assert info.bike_type is None
+        assert info.system_state is None
+        assert info.bike_name == "?99 WSBC001057439S"
+        assert info.ble_profile is BLEProfile.TCX
+        assert info.tcx_generation is TCXGeneration.TCX2
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+
+
+class TestEncryptionMethodSemantics:
+    """Regression tests: an incomplete/unknown result must never be
+    mistaken for ProtocolEncryptionMethod.NONE. ``None`` means "we don't
+    know"; ``ProtocolEncryptionMethod.NONE`` means "confirmed unencrypted"
+    (only ever true for a complete TCU1 record)."""
+
+    def test_not_a_bike_encryption_is_none_not_NONE(self):
+        info = parse_bike_info("Some Headphones", {})
+        assert info.encryption_method is None
+        assert info.encryption_method is not ProtocolEncryptionMethod.NONE
+
+    def test_incomplete_bike_encryption_is_none_not_NONE(self):
+        info = parse_bike_info("SPECIALIZED-TEST", _mfr_data({"89": "dac8c404"}))
+        assert info.complete is False
+        assert info.encryption_method is None
+        assert info.encryption_method is not ProtocolEncryptionMethod.NONE
+
+    def test_complete_tcu1_encryption_is_explicit_NONE(self):
+        info = parse_bike_info(
+            "SPECIALIZED LEVO", _mfr_data({"525": "02000000000000000000"})
+        )
+        assert info.complete is True
+        assert info.encryption_method is ProtocolEncryptionMethod.NONE
+        assert info.encryption_method is not None
+
+    def test_complete_nordic_encryption_is_explicit_aes_ctr(self):
+        info = parse_bike_info(
+            "SPECIALIZED-TEST", _mfr_data({"89": "2a000001423433330601"})
+        )
+        assert info.complete is True
+        assert info.encryption_method is ProtocolEncryptionMethod.AES_CTR
+
+
+class TestBikeInfoIsFrozen:
+    def test_bike_info_is_immutable(self):
+        info = parse_bike_info("Random Device", {})
+        with pytest.raises(AttributeError):
+            setattr(info, "is_bike", True)
+
+    def test_bike_info_is_a_dataclass_instance(self):
+        info = parse_bike_info("Random Device", {})
+        assert isinstance(info, BikeInfo)


### PR DESCRIPTION
Parse TCX generation, HMI identifiers, encryption mode, and bike state from BLE advertisements.