### PR TITLE
Wire TCX telemetry through notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,25 @@ pip install specialized-turbo
 
 ## Quick start
 
-### Stream telemetry
+> **TCX2+ bikes (Vado/Levo/Creo SL, etc.) require identification.** Pass the
+> parsed advertisement (`bike_info`, from `parse_bike_info`) and the bike's
+> AES key (`key`, a `BikeEncryptionKey` fetched out-of-band from the
+> Specialized account keystore) so the connection can run the encrypted
+> identification handshake and negotiate the protocol revision. TCU1 bikes
+> (2018 Levo) need neither — just the address and PIN.
+
+### Stream telemetry (TCX2+)
 
 ```python
 import asyncio
 from specialized_turbo import SpecializedConnection, TelemetryMonitor
+from specialized_turbo import parse_bike_info, BikeEncryptionKey
 
 async def main():
-    async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
+    # bike_info comes from the BLE advertisement; key from your account.
+    async with SpecializedConnection(
+        "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+    ) as conn:
         monitor = TelemetryMonitor(conn)
         await monitor.start()
 
@@ -32,7 +43,9 @@ asyncio.run(main())
 ### Read the snapshot
 
 ```python
-async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
+async with SpecializedConnection(
+    "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+) as conn:
     monitor = TelemetryMonitor(conn)
     await monitor.start()
     await asyncio.sleep(5)
@@ -45,12 +58,15 @@ async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
     print(f"Assist: {snap.motor.assist_level}")
 ```
 
-### Query a single value
+### Query a single value (TCU1)
 
 ```python
 from specialized_turbo import SpecializedConnection, Sender, BatteryChannel
+from specialized_turbo import BLEProfile
 
-async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
+async with SpecializedConnection(
+    "DC:DD:BB:4A:D6:55", pin="946166", generation=BLEProfile.TCU1
+) as conn:
     msg = await conn.request_value(Sender.BATTERY, BatteryChannel.CHARGE_PERCENT)
     print(f"Battery: {msg.converted_value}%")
 ```
@@ -58,14 +74,24 @@ async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
 ### Write commands
 
 ```python
-async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
+async with SpecializedConnection(
+    "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+) as conn:
     await conn.set_assist_level(2)          # TRAIL
     await conn.set_acceleration(50.0)       # 50%
-    await conn.set_shuttle(25)
     await conn.set_assist_percentage(0, 35) # ECO = 35%
+    # set_shuttle(...) is TCU1-only: no verified TCX2+ equivalent.
 ```
 
 ## CLI
+
+> **CLI TCX2+ support is limited.** The CLI cannot yet fetch a bike's AES key
+> from the Specialized account keystore, so commands that need the encrypted
+> identification handshake (`telemetry`, `capture`, and `read` of a TCX2+
+> field) fail with an explicit message on TCX2+ bikes. `scan`, `services`,
+> `read list`/`write list`, and TCU1 `read`/`write` work today. Use the
+> library API (`SpecializedConnection` with `bike_info=` and `key=`) for
+> TCX2+ telemetry and parameter access.
 
 Scan for bikes:
 

--- a/specialized_turbo/__init__.py
+++ b/specialized_turbo/__init__.py
@@ -1,13 +1,23 @@
 """
 specialized_turbo -- talk to Specialized Turbo e-bikes over BLE.
 
-Quick start::
+Quick start (TCX2+ bikes)::
 
     import asyncio
-    from specialized_turbo import SpecializedConnection, TelemetryMonitor
+    from specialized_turbo import (
+        SpecializedConnection,
+        TelemetryMonitor,
+        parse_bike_info,
+    )
+    from specialized_turbo.keystore import BikeEncryptionKey
 
     async def main():
-        async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin="946166") as conn:
+        # ``bike_info`` comes from the BLE advertisement (parse_bike_info)
+        # and ``key`` from the Specialized account keystore -- a TCX2+ bike
+        # cannot be identified without both.
+        async with SpecializedConnection(
+            "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+        ) as conn:
             monitor = TelemetryMonitor(conn)
             await monitor.start()
 
@@ -15,6 +25,10 @@ Quick start::
                 print(f"{msg.field_name} = {msg.converted_value} {msg.unit}")
 
     asyncio.run(main())
+
+``BikeEncryptionKey`` and the keystore models import without the optional
+``aiohttp`` dependency; only the network ``KeystoreClient`` needs the
+``keystore`` extra (``pip install "specialized-turbo[keystore]"``).
 """
 
 from __future__ import annotations
@@ -82,8 +96,40 @@ from .models import (
 )
 from .connection import (
     SpecializedConnection as SpecializedConnection,
+    UnsupportedTCXOperationError as UnsupportedTCXOperationError,
     scan_for_bikes as scan_for_bikes,
     find_bike_by_address as find_bike_by_address,
+)
+from .bike_info import (
+    BikeInfo as BikeInfo,
+    parse_bike_info as parse_bike_info,
+    ProtocolEncryptionMethod as ProtocolEncryptionMethod,
+)
+from .keystore.models import (
+    BikeEncryptionKey as BikeEncryptionKey,
+)
+from .wire_profiles import (
+    ProtocolRevision as ProtocolRevision,
+    TCXGeneration as TCXGeneration,
+    WireProfileError as WireProfileError,
+    UnmappedParameterError as UnmappedParameterError,
+)
+from .identification import (
+    TCXIdentification as TCXIdentification,
+    identify as identify,
+    parse_wire_message as parse_wire_message,
+    WireMessage as WireMessage,
+    IdentificationResult as IdentificationResult,
+    IdentificationPhase as IdentificationPhase,
+    IdentificationError as IdentificationError,
+    IncompleteBikeInfoError as IncompleteBikeInfoError,
+    UnsupportedGenerationError as UnsupportedGenerationError,
+    UnsupportedRevisionError as UnsupportedRevisionError,
+    MissingEncryptionKeyError as MissingEncryptionKeyError,
+    MalformedIVError as MalformedIVError,
+    MalformedProtocolResponseError as MalformedProtocolResponseError,
+    DecryptionError as DecryptionError,
+    IdentificationNakError as IdentificationNakError,
 )
 from .telemetry import (
     TelemetryMonitor as TelemetryMonitor,
@@ -123,6 +169,7 @@ from .session import (
 from .transport import (
     BLETraceEvent as BLETraceEvent,
     TCXNotificationTransport as TCXNotificationTransport,
+    TCXProtocolNotNegotiatedError as TCXProtocolNotNegotiatedError,
     TCXRequestTimeoutError as TCXRequestTimeoutError,
     TCXTransportDisconnectedError as TCXTransportDisconnectedError,
 )
@@ -200,8 +247,33 @@ __all__ = [
     "TelemetrySnapshot",
     # Connection
     "SpecializedConnection",
+    "UnsupportedTCXOperationError",
     "scan_for_bikes",
     "find_bike_by_address",
+    # Advertisement parsing / identification
+    "BikeInfo",
+    "parse_bike_info",
+    "ProtocolEncryptionMethod",
+    "BikeEncryptionKey",
+    "ProtocolRevision",
+    "TCXGeneration",
+    "WireProfileError",
+    "UnmappedParameterError",
+    "TCXIdentification",
+    "identify",
+    "parse_wire_message",
+    "WireMessage",
+    "IdentificationResult",
+    "IdentificationPhase",
+    "IdentificationError",
+    "IncompleteBikeInfoError",
+    "UnsupportedGenerationError",
+    "UnsupportedRevisionError",
+    "MissingEncryptionKeyError",
+    "MalformedIVError",
+    "MalformedProtocolResponseError",
+    "DecryptionError",
+    "IdentificationNakError",
     # Telemetry
     "TelemetryMonitor",
     "run_telemetry_session",
@@ -238,6 +310,7 @@ __all__ = [
     # TCX notification transport
     "BLETraceEvent",
     "TCXNotificationTransport",
+    "TCXProtocolNotNegotiatedError",
     "TCXRequestTimeoutError",
     "TCXTransportDisconnectedError",
     # Coordinator helpers

--- a/specialized_turbo/cli.py
+++ b/specialized_turbo/cli.py
@@ -18,9 +18,11 @@ import time
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from .connection import scan_for_bikes, SpecializedConnection
+from .identification import IdentificationError
 from .parameters import all_tcx_fields
 from .protocol import (
     all_field_defs,
+    BLEProfile,
 )
 from .telemetry import run_telemetry_session
 from .transport import BLETraceEvent
@@ -134,15 +136,30 @@ async def _cmd_read(args: argparse.Namespace) -> None:
         print("Use 'read list' to see available fields.")
         sys.exit(1)
 
+    if tcx_param_id is not None:
+        # A TCX2+ read must go through the identification handshake (which
+        # resolves the app-level BikeParameter to a revision-specific wire
+        # id). That needs the bike's advertisement (BikeInfo) and its AES key
+        # from the account keystore -- neither of which the CLI can fetch
+        # yet. Fail explicitly instead of silently addressing a raw enum id.
+        print(
+            f"Reading TCX2+ field '{field_name}' is not supported by the CLI "
+            "yet: it requires an identification handshake using the bike's "
+            "advertisement (BikeInfo) and its AES key from the Specialized "
+            "account keystore. Use the library API instead "
+            "(SpecializedConnection with bike_info= and key=, then "
+            "request_tcx_parameter)."
+        )
+        sys.exit(1)
+
+    assert tcu1_key is not None
+    sender, channel = tcu1_key
     print(f"Connecting to {args.address} to read '{field_name}' ...")
 
-    async with SpecializedConnection(args.address, pin=args.pin) as conn:
-        if tcx_param_id is not None:
-            msg = await conn.request_tcx_value(tcx_param_id)
-        else:
-            assert tcu1_key is not None
-            sender, channel = tcu1_key
-            msg = await conn.request_value(sender, channel)
+    async with SpecializedConnection(
+        args.address, pin=args.pin, generation=BLEProfile.TCU1
+    ) as conn:
+        msg = await conn.request_value(sender, channel)
         if args.format == "json":
             if msg.nak_reason is not None:
                 print(
@@ -224,7 +241,13 @@ async def _cmd_write(args: argparse.Namespace) -> None:
 
     print(f"Connecting to {args.address} to write '{field_name}' = {raw_value} ...")
 
-    async with SpecializedConnection(args.address, pin=args.pin) as conn:
+    # ``write list`` fields come from the TCU1 field table, so drive the
+    # write over the TCU1 profile (no identification handshake needed). A
+    # TCX2+ write must instead go through the library API's
+    # write_tcx_parameter with a fully identified connection.
+    async with SpecializedConnection(
+        args.address, pin=args.pin, generation=BLEProfile.TCU1
+    ) as conn:
         await conn.write_command(command)
         print(
             f"Wrote {field_name} = {raw_value} (raw: {wire_value}, bytes: {command.hex()})"
@@ -386,6 +409,19 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(coro)
     except KeyboardInterrupt:
         print("\nInterrupted.")
+    except IdentificationError as exc:
+        # A TCX2+ command reached the identification handshake but could not
+        # complete it (typically no BikeInfo/key). Surface a clear, typed
+        # failure instead of an opaque traceback or AttributeError.
+        print(f"\nError: {exc}")
+        print(
+            "TCX2+ bikes require an identification handshake using the bike's "
+            "advertisement (BikeInfo) and its AES key from the Specialized "
+            "account keystore. The CLI cannot fetch these yet, so connecting "
+            "to a TCX bike is not supported from the CLI. Use the library API "
+            "(SpecializedConnection with bike_info= and key=)."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/specialized_turbo/connection.py
+++ b/specialized_turbo/connection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -15,7 +16,15 @@ from bleak import BleakClient, BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
-from .coordinator_helpers import identify_tcx
+from .bike_info import BikeInfo
+from .identification import (
+    IdentificationResult,
+    TCXIdentification,
+    WireMessage,
+    parse_wire_message,
+)
+from .keystore.models import BikeEncryptionKey
+from .parameters import BikeParameter
 from .protocol import (
     BLEProfile,
     build_request,
@@ -28,14 +37,20 @@ from .protocol import (
     parse_tcx_message,
     ParsedMessage,
 )
-from .session import ProtocolSession, TCU1Session, TCXSession
+from .session import ProtocolSession, TCU1Session
 from .transport import (
     NotificationCallback,
     TCXNotificationTransport,
     TraceCallback,
 )
+from .wire_profiles import ProtocolRevision
 
 logger = logging.getLogger(__name__)
+
+#: Sentinel used when no ``BikeInfo`` is supplied to :class:`SpecializedConnection`.
+#: ``complete=False`` routes straight into :class:`~specialized_turbo.
+#: identification.IncompleteBikeInfoError` instead of an ``AttributeError``.
+_UNKNOWN_BIKE_INFO = BikeInfo(name="", bike_name="", is_bike=False, complete=False)
 
 
 # ---------------------------------------------------------------------------
@@ -104,8 +119,11 @@ class SpecializedConnection:
         *,
         pin: str | None = None,
         generation: BLEProfile = BLEProfile.TCX,
+        bike_info: BikeInfo | None = None,
+        key: BikeEncryptionKey | None = None,
         disconnect_callback: Callable[[BleakClient], None] | None = None,
         trace_callback: TraceCallback | None = None,
+        identification_timeout: float | None = None,
     ) -> None:
         """
         Parameters
@@ -118,14 +136,33 @@ class SpecializedConnection:
         generation :
             Protocol generation (TCU1 or TCX).  Determines which
             GATT UUIDs to use.  Defaults to TCX.
+        bike_info :
+            The pre-connect advertisement parse (see
+            :func:`specialized_turbo.bike_info.parse_bike_info`).  Required
+            for a TCX connection: it must be ``complete`` and carry a
+            ``tcx_generation`` so the official identification handshake
+            (:class:`~specialized_turbo.identification.TCXIdentification`)
+            can select the right wire-id map.  Ignored for TCU1.
+        key :
+            The bike's AES-128 encryption key, fetched out-of-band from the
+            account keystore (never available over BLE). Required for a
+            TCX connection, since every complete TCX ``BikeInfo`` implies
+            AES-CTR encryption. Never logged -- see
+            :class:`~specialized_turbo.keystore.models.BikeEncryptionKey`.
         disconnect_callback :
             Optional callback invoked if the bike disconnects unexpectedly.
         trace_callback :
             Optional callback receiving every raw TCX write and notification.
+        identification_timeout :
+            Optional per-request timeout (seconds) for each identification
+            step. Defaults to the transport's own timeout.
         """
         self._address = address_or_device
         self._pin = pin
         self._generation = generation
+        self._bike_info = bike_info
+        self._key = key
+        self._identification_timeout = identification_timeout
         self._char_notify = get_char_notify(generation)
         self._char_request_read = get_char_request_read(generation)
         self._char_request_write = get_char_request_write(generation)
@@ -137,6 +174,8 @@ class SpecializedConnection:
         self._tcx_transport: TCXNotificationTransport | None = None
         self._telemetry_callback: NotificationCallback | None = None
         self._notification_started = False
+        self._identification_result: IdentificationResult | None = None
+        self._protocol_revision: ProtocolRevision | None = None
 
     # -- context manager --------------------------------------------------
 
@@ -189,26 +228,61 @@ class SpecializedConnection:
 
         # Create protocol session
         if self._generation == BLEProfile.TCX:
-            self._session = TCXSession()
             transport = TCXNotificationTransport(
                 self._client,
-                session=self._session,
                 trace_callback=self._trace_callback,
             )
             self._tcx_transport = transport
-            await transport.subscribe_for_identification()
-            session = await identify_tcx(transport)
-            if not self._client.is_connected:
-                raise RuntimeError(
-                    f"Disconnected from {self._address} during identification"
+            bike_info = (
+                self._bike_info if self._bike_info is not None else _UNKNOWN_BIKE_INFO
+            )
+            identification = TCXIdentification(
+                transport,
+                bike_info,
+                self._key,
+                timeout=self._identification_timeout,
+            )
+            try:
+                result = await identification.run()
+                self._session = transport.session
+                transport.protocol_revision = result.protocol_revision
+                self._protocol_revision = result.protocol_revision
+                self._identification_result = result
+                await transport.subscribe_for_realtime()
+            except Exception:
+                logger.warning(
+                    "TCX connect failed during identification/setup "
+                    "(failed_phase=%s, phase=%s)",
+                    identification.failed_phase,
+                    identification.phase,
                 )
-            self._session = session
-            transport.session = session
-            await transport.subscribe_for_realtime()
+                await self._reset_after_failed_tcx_connect()
+                raise
         else:
             self._session = TCU1Session()
 
         logger.info("Connection established to %s", self._address)
+
+    async def _reset_after_failed_tcx_connect(self) -> None:
+        """Return to a clean, retryable state after a failed TCX identification.
+
+        Never leaves partial state (a stale transport, a half-negotiated
+        session) behind: a subsequent :meth:`connect` call starts fresh.
+        """
+        self._tcx_transport = None
+        self._session = TCU1Session()
+        self._protocol_revision = None
+        self._identification_result = None
+        client = self._client
+        self._client = None
+        if client is not None and client.is_connected:
+            try:
+                await client.disconnect()
+            except Exception:
+                logger.debug(
+                    "Failed to disconnect after failed TCX identification",
+                    exc_info=True,
+                )
 
     async def disconnect(self) -> None:
         """Cleanly disconnect from the bike."""
@@ -227,6 +301,8 @@ class SpecializedConnection:
             logger.info("Disconnected from %s", self._address)
         self._client = None
         self._tcx_transport = None
+        self._protocol_revision = None
+        self._identification_result = None
 
     @property
     def is_connected(self) -> bool:
@@ -236,6 +312,26 @@ class SpecializedConnection:
     def session(self) -> ProtocolSession:
         """The active protocol session (TCU1Session or TCXSession)."""
         return self._session
+
+    @property
+    def protocol_revision(self) -> ProtocolRevision | None:
+        """The active TCX generation/revision, negotiated during identification.
+
+        Read-only: ``None`` for a TCU1 connection, or before a TCX
+        identification handshake has completed. Consumers should use this
+        (rather than assuming a generation/revision) to know which wire-id
+        map is in effect -- see :mod:`specialized_turbo.wire_profiles`.
+        """
+        return self._protocol_revision
+
+    @property
+    def identification_result(self) -> IdentificationResult | None:
+        """The full result of the TCX identification handshake, if any.
+
+        Read-only: ``None`` for a TCU1 connection, or before identification
+        has completed.
+        """
+        return self._identification_result
 
     # -- notifications ----------------------------------------------------
 
@@ -317,6 +413,16 @@ class SpecializedConnection:
         """
         Query a TCX2+ value through a write/notification transaction.
 
+        .. deprecated::
+           *param_id* is treated directly as the wire command id (the
+           legacy behaviour from before generation/revision-aware wire
+           mapping existed).  It only returns the right value for
+           parameters whose wire id happens to equal their
+           :class:`~specialized_turbo.parameters.BikeParameter` value.  New
+           code should call :meth:`request_tcx_parameter` instead, which
+           resolves the wire id through the ``ProtocolRevision`` negotiated
+           during identification (see :attr:`protocol_revision`).
+
         Writes a CRC-framed parameter request without response, then waits for
         the matching notification from the bike.
 
@@ -324,6 +430,14 @@ class SpecializedConnection:
         ``nak_reason`` set to the rejection code.  A warning is logged
         with the parameter and reason for diagnostics.
         """
+        warnings.warn(
+            "request_tcx_value(param_id) addresses the bike by a raw wire "
+            "id and is deprecated; use request_tcx_parameter(BikeParameter) "
+            "instead, which resolves the wire id through the negotiated "
+            "ProtocolRevision.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._client is None or self._tcx_transport is None:
             raise RuntimeError("Not connected")
         logger.debug("TCX notification request param %d", param_id)
@@ -345,16 +459,68 @@ class SpecializedConnection:
 
         return msg
 
+    async def request_tcx_parameter(
+        self,
+        param: BikeParameter,
+        *,
+        timeout: float | None = None,
+    ) -> WireMessage:
+        """
+        Query a TCX2+ value by its stable app-level ``BikeParameter`` id.
+
+        Resolves *param* to a wire command id through the
+        :class:`~specialized_turbo.wire_profiles.ProtocolRevision`
+        negotiated during identification (see :attr:`protocol_revision`),
+        then correlates the response by that wire id.  This is the
+        profile-aware replacement for :meth:`request_tcx_value`: it never
+        assumes a ``BikeParameter`` value coincides with its wire id.
+
+        If the bike rejects the request the returned :class:`~specialized_
+        turbo.identification.WireMessage` has ``nak_reason`` set, and a
+        warning is logged with the parameter and reason for diagnostics.
+        """
+        if self._client is None or self._tcx_transport is None:
+            raise RuntimeError("Not connected")
+        revision = self._protocol_revision
+        if revision is None:
+            raise RuntimeError(
+                "TCX identification has not completed; no protocol "
+                "revision has been negotiated"
+            )
+        logger.debug("TCX notification request %s", param.name)
+        response = await self._tcx_transport.request_bike_parameter(
+            param, timeout=timeout
+        )
+        msg = parse_wire_message(response, revision.generation, revision.revision)
+
+        if msg.nak_reason is not None:
+            logger.warning(
+                "Bike rejected TCX request for %s (wire=0x%04x, reason=0x%02x)",
+                param.name,
+                msg.wire_id,
+                msg.nak_reason,
+            )
+
+        return msg
+
     # -- write commands ----------------------------------------------------
 
     async def write_command(self, data: bytes | bytearray) -> None:
         """
-        Send a write command to the bike.
+        Send a raw write command to the bike.
 
-        *data* is the raw command payload.  For TCU1, pass the bare
-        ``[sender, channel, value…]`` bytes.  For TCX, pass the
-        ``[param_id_be, value…]`` bytes — they will be CRC-framed
-        and encrypted through the session automatically.
+        .. deprecated::
+           For TCX, *data* is treated as an already wire-ready
+           ``[wire_id_be, value…]`` payload -- the caller is responsible
+           for resolving the wire id themselves (e.g. via
+           :mod:`specialized_turbo.wire_profiles`).  Passing a raw
+           :class:`~specialized_turbo.parameters.BikeParameter` value here
+           only writes the intended parameter if it happens to coincide
+           with its wire id.  New code addressing a TCX2+ parameter should
+           call :meth:`write_tcx_parameter` instead, which resolves the
+           wire id through the negotiated :attr:`protocol_revision`. TCU1
+           callers are unaffected: pass the bare
+           ``[sender, channel, value…]`` bytes as before.
         """
         if self._client is None:
             raise RuntimeError("Not connected")
@@ -370,6 +536,27 @@ class SpecializedConnection:
             packed = self._session.pack(data)
             logger.debug("Write command: %s", packed.hex())
             await self._client.write_gatt_char(self._char_write, packed)
+
+    async def write_tcx_parameter(
+        self,
+        param: BikeParameter,
+        data: bytes | bytearray,
+    ) -> None:
+        """
+        Write a TCX2+ value by its stable app-level ``BikeParameter`` id.
+
+        Resolves *param* to a wire command id through the negotiated
+        :attr:`protocol_revision` before writing -- the profile-aware
+        replacement for :meth:`write_command` on the TCX path.
+        """
+        if self._client is None or self._tcx_transport is None:
+            raise RuntimeError("Not connected")
+        if self._protocol_revision is None:
+            raise RuntimeError(
+                "TCX identification has not completed; no protocol "
+                "revision has been negotiated"
+            )
+        await self._tcx_transport.write_bike_parameter(param, data)
 
     async def set_assist_level(self, level: int) -> None:
         """Set the assist level (0=OFF, 1=ECO, 2=TRAIL, 3=TURBO)."""

--- a/specialized_turbo/connection.py
+++ b/specialized_turbo/connection.py
@@ -262,7 +262,9 @@ class SpecializedConnection:
             try:
                 result = await identification.run()
                 self._session = transport.session
-                transport.protocol_revision = result.protocol_revision
+                # identification.run() already installs the negotiated
+                # revision on the transport; keep only the connection's own
+                # active revision here.
                 self._protocol_revision = result.protocol_revision
                 self._identification_result = result
                 await transport.subscribe_for_realtime()

--- a/specialized_turbo/connection.py
+++ b/specialized_turbo/connection.py
@@ -47,6 +47,16 @@ from .wire_profiles import ProtocolRevision
 
 logger = logging.getLogger(__name__)
 
+
+class UnsupportedTCXOperationError(RuntimeError):
+    """A TCU1 convenience write has no verified TCX2+ ``BikeParameter`` equivalent.
+
+    Raised instead of guessing a wire id for an operation (e.g. shuttle)
+    that has no confirmed mapping on the TCX2+ protocol, so a TCX write can
+    never silently address the wrong parameter.
+    """
+
+
 #: Sentinel used when no ``BikeInfo`` is supplied to :class:`SpecializedConnection`.
 #: ``complete=False`` routes straight into :class:`~specialized_turbo.
 #: identification.IncompleteBikeInfoError` instead of an ``AttributeError``.
@@ -103,14 +113,21 @@ class SpecializedConnection:
     """
     Async BLE connection to a Specialized Turbo bike.
 
-    Usage::
+    TCX2+ bikes require the pre-connect advertisement parse (*bike_info*, see
+    :func:`specialized_turbo.bike_info.parse_bike_info`) and the AES key
+    fetched out-of-band from the account keystore (*key*, a
+    :class:`~specialized_turbo.keystore.models.BikeEncryptionKey`) so the
+    official identification handshake can run and negotiate the protocol
+    revision. TCU1 bikes need neither. Usage::
 
-        async with SpecializedConnection("DC:DD:BB:4A:D6:55", pin=946166) as conn:
+        async with SpecializedConnection(
+            "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+        ) as conn:
             await conn.subscribe_notifications(my_callback)
             await asyncio.sleep(30)
 
-    Handles connecting, BLE pairing (passkey entry), subscribing to
-    telemetry notifications, and parameter queries.
+    Handles connecting, BLE pairing (passkey entry), the TCX identification
+    handshake, subscribing to telemetry notifications, and parameter queries.
     """
 
     def __init__(
@@ -314,13 +331,28 @@ class SpecializedConnection:
         return self._session
 
     @property
-    def protocol_revision(self) -> ProtocolRevision | None:
+    def active_revision(self) -> ProtocolRevision | None:
         """The active TCX generation/revision, negotiated during identification.
 
+        This is the canonical accessor consumers should read (e.g.
+        :class:`~specialized_turbo.telemetry.TelemetryMonitor`, via the
+        :class:`~specialized_turbo.telemetry.RevisionAwareConnection`
+        structural protocol) to know which wire-id map is in effect -- see
+        :mod:`specialized_turbo.wire_profiles`.
+
         Read-only: ``None`` for a TCU1 connection, or before a TCX
-        identification handshake has completed. Consumers should use this
-        (rather than assuming a generation/revision) to know which wire-id
-        map is in effect -- see :mod:`specialized_turbo.wire_profiles`.
+        identification handshake has completed.
+        """
+        return self._protocol_revision
+
+    @property
+    def protocol_revision(self) -> ProtocolRevision | None:
+        """Alias of :attr:`active_revision`.
+
+        Kept for symmetry with
+        :attr:`~specialized_turbo.identification.IdentificationResult.protocol_revision`
+        and :attr:`~specialized_turbo.transport.TCXNotificationTransport.protocol_revision`.
+        New code should prefer :attr:`active_revision`.
         """
         return self._protocol_revision
 
@@ -527,6 +559,15 @@ class SpecializedConnection:
         if self._generation == BLEProfile.TCX:
             if self._tcx_transport is None:
                 raise RuntimeError("TCX transport is not initialized")
+            warnings.warn(
+                "write_command() on a TCX connection treats data as an "
+                "already wire-ready [wire_id_be, value...] payload and is "
+                "deprecated; use write_tcx_parameter(BikeParameter, value), "
+                "which resolves the wire id through the negotiated "
+                "ProtocolRevision. (TCU1 callers are unaffected.)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             packed = self._session.pack(data)
             logger.debug("TCX write command: %s", packed.hex())
             from .protocol import BLEServiceID
@@ -558,8 +599,27 @@ class SpecializedConnection:
             )
         await self._tcx_transport.write_bike_parameter(param, data)
 
+    #: TCX2+ profile-scaling parameters for ECO/TRAIL/TURBO, indexed to match
+    #: :meth:`set_assist_percentage`'s ``level_index`` (0=ECO, 1=TRAIL, 2=TURBO).
+    _TCX_PROFILE_SCALING = (
+        BikeParameter.MOTOR_PROFILE_SCALING_ECO_SETTING,
+        BikeParameter.MOTOR_PROFILE_SCALING_TRAIL_SETTING,
+        BikeParameter.MOTOR_PROFILE_SCALING_TURBO_SETTING,
+    )
+
     async def set_assist_level(self, level: int) -> None:
-        """Set the assist level (0=OFF, 1=ECO, 2=TRAIL, 3=TURBO)."""
+        """Set the assist level (0=OFF, 1=ECO, 2=TRAIL, 3=TURBO).
+
+        On TCX2+ this maps to ``MOTOR_ACTIVE_TRAVEL_MODE`` through the
+        negotiated protocol revision; on TCU1 it keeps the legacy
+        sender/channel write unchanged.
+        """
+        if self._generation == BLEProfile.TCX:
+            await self.write_tcx_parameter(
+                BikeParameter.MOTOR_ACTIVE_TRAVEL_MODE, bytes([level])
+            )
+            return
+
         from .protocol import build_write_command
 
         await self.write_command(
@@ -567,7 +627,23 @@ class SpecializedConnection:
         )
 
     async def set_assist_percentage(self, level_index: int, value: int) -> None:
-        """Set assist percentage for a level (level_index: 0=ECO, 1=TRAIL, 2=TURBO; value: 0-100)."""
+        """Set assist percentage for a level (level_index: 0=ECO, 1=TRAIL, 2=TURBO; value: 0-100).
+
+        On TCX2+ this maps to the matching ``MOTOR_PROFILE_SCALING_*_SETTING``
+        parameter through the negotiated protocol revision; on TCU1 it keeps
+        the legacy sender/channel write unchanged.
+        """
+        if self._generation == BLEProfile.TCX:
+            try:
+                param = self._TCX_PROFILE_SCALING[level_index]
+            except IndexError:
+                raise ValueError(
+                    f"level_index must be 0 (ECO), 1 (TRAIL), or 2 (TURBO), "
+                    f"got {level_index}"
+                ) from None
+            await self.write_tcx_parameter(param, bytes([value]))
+            return
+
         from .protocol import build_write_command
 
         await self.write_command(
@@ -575,16 +651,39 @@ class SpecializedConnection:
         )
 
     async def set_acceleration(self, percent: float) -> None:
-        """Set acceleration sensitivity (0-100%)."""
+        """Set acceleration sensitivity (0-100%).
+
+        On TCX2+ this maps to ``MOTOR_ACCELERATION_RESPONSE`` through the
+        negotiated protocol revision (same ``percent * 60 + 3000`` wire
+        encoding); on TCU1 it keeps the legacy sender/channel write unchanged.
+        """
+        raw = int(percent * 60 + 3000)
+        if self._generation == BLEProfile.TCX:
+            await self.write_tcx_parameter(
+                BikeParameter.MOTOR_ACCELERATION_RESPONSE, raw.to_bytes(2, "little")
+            )
+            return
+
         from .protocol import build_write_command
 
-        raw = int(percent * 60 + 3000)
         await self.write_command(
             build_write_command(0x02, 0x07, raw.to_bytes(2, "little"))
         )
 
     async def set_shuttle(self, value: int) -> None:
-        """Set shuttle value (0-100)."""
+        """Set shuttle value (0-100).
+
+        TCU1 only: there is no verified TCX2+ ``BikeParameter`` equivalent
+        for the TCU1 shuttle write, so this raises
+        :class:`UnsupportedTCXOperationError` on a TCX connection rather than
+        guessing a wire id.
+        """
+        if self._generation == BLEProfile.TCX:
+            raise UnsupportedTCXOperationError(
+                "set_shuttle has no verified TCX2+ BikeParameter equivalent; "
+                "it is supported on TCU1 only"
+            )
+
         from .protocol import build_write_command
 
         await self.write_command(build_write_command(0x01, 0x15, bytes([value])))

--- a/specialized_turbo/coordinator_helpers.py
+++ b/specialized_turbo/coordinator_helpers.py
@@ -301,10 +301,12 @@ async def identify_tcx(
        New code should use :class:`specialized_turbo.identification.TCXIdentification`
        (or the :func:`specialized_turbo.identification.identify` convenience
        wrapper), which fetches the real key from the account keystore and
-       negotiates generation/revision-correct wire ids.  This function is
-       kept only so existing callers (e.g. :class:`SpecializedConnection`)
-       keep importing and calling it; it now always returns an unencrypted
-       :class:`TCXSession`.
+       negotiates generation/revision-correct wire ids.
+       :class:`~specialized_turbo.connection.SpecializedConnection` no longer
+       calls this shim -- it drives ``TCXIdentification`` directly.  This
+       function is retained only for backward compatibility with any
+       out-of-tree callers still importing it; it now always returns an
+       unencrypted :class:`TCXSession`.
     """
     steps = [
         BikeParameter.SYSTEM_GET_NEW_VI,

--- a/specialized_turbo/coordinator_helpers.py
+++ b/specialized_turbo/coordinator_helpers.py
@@ -14,14 +14,14 @@ import logging
 
 from bleak import BleakClient
 
-from .encryption import derive_key
 from .framing import (
     is_framed_packet,
     is_nak_packet,
     parse_nak_packet,
 )
+from .identification import WireMessage, parse_wire_message
 from .models import TelemetrySnapshot
-from .parameters import BikeParameter
+from .parameters import BikeParameter, get_tcx_field
 from .protocol import (
     TCU1_POLL_FIELDS,
     build_request,
@@ -31,6 +31,7 @@ from .protocol import (
 )
 from .session import ProtocolSession, TCXSession
 from .transport import TCXNotificationTransport, TCXTransportDisconnectedError
+from .wire_profiles import ProtocolRevision, UnmappedParameterError, wire_id_for
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,108 @@ def parse_notification(
     return parse_message(data)
 
 
+def _wire_message_to_parsed_message(msg: WireMessage) -> ParsedMessage:
+    """Adapt a profile-aware :class:`WireMessage` into a legacy :class:`ParsedMessage`.
+
+    Reuses the ``BikeParameter``-keyed field metadata in
+    :mod:`specialized_turbo.parameters` (name/unit/conversion) so existing
+    consumers (:meth:`TelemetrySnapshot.update_from_message`, the
+    ``_FIELD_NAME_MAP`` field-name routing) keep working unchanged.  Unlike
+    :func:`specialized_turbo.protocol.parse_tcx_message`, ``sender``/
+    ``channel`` here are derived from *msg.wire_id* -- the actual wire
+    command id -- rather than assuming it equals the ``BikeParameter`` enum
+    value.
+    """
+    sender = msg.wire_id >> 8
+    channel = msg.wire_id & 0xFF
+
+    if msg.is_nak:
+        return ParsedMessage(
+            sender=sender,
+            channel=channel,
+            raw_value=msg.wire_id,
+            converted_value=None,
+            field_name=None,
+            unit="",
+            nak_reason=msg.nak_reason,
+        )
+
+    field_def = get_tcx_field(int(msg.parameter)) if msg.parameter is not None else None
+    payload = msg.data.rstrip(b"\x00")
+
+    if field_def is None:
+        # Unknown/unmapped parameter -- surface the raw bytes without a name.
+        raw = int.from_bytes(payload, "little") if payload else 0
+        return ParsedMessage(
+            sender=sender,
+            channel=channel,
+            raw_value=raw,
+            converted_value=raw if payload else None,
+            field_name=None,
+            unit="",
+        )
+
+    if not payload:
+        return ParsedMessage(
+            sender=sender,
+            channel=channel,
+            raw_value=0,
+            converted_value=None,
+            field_name=field_def.name,
+            unit=field_def.unit,
+        )
+
+    actual_size = min(field_def.data_size, len(payload))
+    raw = int.from_bytes(payload[:actual_size], "little")
+    return ParsedMessage(
+        sender=sender,
+        channel=channel,
+        raw_value=raw,
+        converted_value=field_def.convert(raw),
+        field_name=field_def.name,
+        unit=field_def.unit,
+    )
+
+
+def parse_tcx_wire_payload(
+    payload: bytes | bytearray,
+    revision: ProtocolRevision,
+) -> ParsedMessage:
+    """Profile-aware parse of an already-unpacked TCX response *payload*.
+
+    Resolves *payload*'s wire id back to a ``BikeParameter`` for the given
+    *revision* (via :func:`specialized_turbo.identification.parse_wire_message`,
+    which uses :mod:`specialized_turbo.wire_profiles`) instead of assuming
+    the wire id equals the ``BikeParameter`` enum value, then adapts the
+    result into a legacy :class:`ParsedMessage`.
+
+    *payload* must already be CRC-stripped and (for an encrypted session)
+    decrypted -- i.e. what :meth:`TCXNotificationTransport.request_wire_parameter`
+    returns, or what :func:`parse_tcx_notification` passes it internally.
+    """
+    wire_msg = parse_wire_message(payload, revision.generation, revision.revision)
+    return _wire_message_to_parsed_message(wire_msg)
+
+
+def parse_tcx_notification(
+    session: TCXSession,
+    data: bytes | bytearray,
+    revision: ProtocolRevision,
+) -> ParsedMessage:
+    """Unpack a raw TCX notification/response and parse it profile-aware.
+
+    Pure function: unpacks *data* through *session* (CRC-strip and, for an
+    encrypted session, AES-CTR decrypt) and resolves it to a
+    :class:`ParsedMessage` for the negotiated *revision* via
+    :func:`parse_tcx_wire_payload`.  Use this for raw bytes straight off a
+    BLE notification; if a transport has already unpacked the payload (e.g.
+    :meth:`TCXNotificationTransport.request_wire_parameter`), call
+    :func:`parse_tcx_wire_payload` directly instead.
+    """
+    payload = session.unpack(data)
+    return parse_tcx_wire_payload(payload, revision)
+
+
 async def poll_tcu1(
     client: BleakClient,
     char_request_write: str,
@@ -106,43 +209,102 @@ async def poll_tcu1(
 async def poll_tcx(
     transport: TCXNotificationTransport,
     snapshot: TelemetrySnapshot,
+    revision: ProtocolRevision,
 ) -> bool:
     """Poll TCX fields through write/notification transactions.
+
+    Each entry in :data:`TCX_POLL_PARAMS` is resolved to its wire command id
+    for the active *revision* (see :mod:`specialized_turbo.wire_profiles`)
+    and requested through the transport's wire-aware
+    :meth:`TCXNotificationTransport.request_wire_parameter`.  Parameters with
+    no known wire id for this revision, NAKed reads, and any parse/snapshot
+    failure (e.g. an unexpectedly short or malformed response) are contained
+    to the current parameter and skipped -- logged with the parameter and
+    wire id for context -- so one bad field can't abort the rest of the
+    poll.  A bike disconnect is the one failure that propagates immediately
+    to the caller.
 
     Returns ``True`` if any field was updated.
     """
     updated = False
     for param in TCX_POLL_PARAMS:
         try:
-            response = await transport.request_parameter(int(param))
-            msg = parse_tcx_message(response)
-            if msg.nak_reason is not None:
-                logger.debug(
-                    "TCX param %d rejected with reason 0x%02x",
-                    int(param),
-                    msg.nak_reason,
-                )
-                continue
-            snapshot.update_from_message(msg)
-            updated = True
+            wire_id = wire_id_for(param, revision.generation, revision.revision)
+        except UnmappedParameterError:
+            logger.debug(
+                "No wire id for %s on %s revision 0x%02x; skipping poll",
+                param.name,
+                revision.generation.name,
+                revision.revision,
+            )
+            continue
+        try:
+            payload = await transport.request_wire_parameter(wire_id)
         except TCXTransportDisconnectedError:
             raise
         except Exception:  # noqa: BLE001
-            logger.debug("Failed to poll TCX param %d", int(param), exc_info=True)
+            logger.debug(
+                "Failed to poll TCX %s (wire 0x%04x)",
+                param.name,
+                wire_id,
+                exc_info=True,
+            )
+            continue
+        try:
+            msg = parse_tcx_wire_payload(payload, revision)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Failed to parse TCX %s (wire 0x%04x) response: %s",
+                param.name,
+                wire_id,
+                payload.hex(),
+                exc_info=True,
+            )
+            continue
+        if msg.nak_reason is not None:
+            logger.debug(
+                "TCX %s (wire 0x%04x) rejected with reason 0x%02x",
+                param.name,
+                wire_id,
+                msg.nak_reason,
+            )
+            continue
+        try:
+            snapshot.update_from_message(msg)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Failed to update snapshot from TCX %s (wire 0x%04x)",
+                param.name,
+                wire_id,
+                exc_info=True,
+            )
+            continue
+        updated = True
     return updated
 
 
 async def identify_tcx(
     transport: TCXNotificationTransport,
 ) -> TCXSession:
-    """Run the TCX identification handshake and return a session.
+    """Run the legacy identification read sequence and return a session.
 
-    Executes the full 7-step identification sequence.  Step 4 may
-    return encryption key material.  Returns an encrypted
-    :class:`TCXSession` if a key is found, or an unencrypted one
-    otherwise.
+    .. deprecated::
+       This predates the official TCX2+ handshake in
+       :mod:`specialized_turbo.identification`.  It used to derive an
+       "encryption key" from the ``BATTERY1_FIRMWARE`` response -- that
+       response is a 3-byte firmware version string, never key material,
+       and no valid AES key can be recovered from it (the length guard
+       below meant this path never actually fired on a real bike; it just
+       silently fell back to an unencrypted session).  That false key
+       derivation has been removed outright rather than left as dead code.
 
-    If the handshake fails, returns an unencrypted session.
+       New code should use :class:`specialized_turbo.identification.TCXIdentification`
+       (or the :func:`specialized_turbo.identification.identify` convenience
+       wrapper), which fetches the real key from the account keystore and
+       negotiates generation/revision-correct wire ids.  This function is
+       kept only so existing callers (e.g. :class:`SpecializedConnection`)
+       keep importing and calling it; it now always returns an unencrypted
+       :class:`TCXSession`.
     """
     steps = [
         BikeParameter.SYSTEM_GET_NEW_VI,
@@ -153,8 +315,6 @@ async def identify_tcx(
         BikeParameter.SYSTEM_MOTOR_TYPE,
         BikeParameter.SYSTEM_EBIKE_SERIAL_NUMBER,
     ]
-
-    key_response: bytes | None = None
 
     try:
         for param in steps:
@@ -170,10 +330,6 @@ async def identify_tcx(
                     echoed,
                     reason,
                 )
-                continue
-
-            if param == BikeParameter.BATTERY1_FIRMWARE:
-                key_response = inner
     except TCXTransportDisconnectedError:
         raise
     except Exception:  # noqa: BLE001
@@ -181,38 +337,5 @@ async def identify_tcx(
             "TCX identification handshake failed, using unencrypted session",
             exc_info=True,
         )
-        return TCXSession()
 
-    if key_response is None or len(key_response) < 4:
-        return TCXSession()
-
-    # key_response is the inner payload with CRC and any NAK already
-    # filtered above.  Skip the 2-byte param ID to reach key material.
-    key_data = key_response[2:].rstrip(b"\x00")
-
-    if len(key_data) == 0:
-        logger.debug(
-            "Encryption key response was empty — bike may not require encryption"
-        )
-        return TCXSession()
-
-    # A valid base64 encryption key is 64 chars (~48 decoded bytes).
-    # Short responses (e.g. a single firmware-version byte) are not keys.
-    if len(key_data) < 20:
-        logger.debug(
-            "Key response too short for encryption (%d bytes) "
-            "— bike does not require encryption",
-            len(key_data),
-        )
-        return TCXSession()
-
-    try:
-        aes_key = derive_key(key_data.decode("ascii"))
-        logger.info("TCX encryption key derived, using encrypted session")
-        return TCXSession(key=aes_key, iv=b"\x00" * 16)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "Failed to derive encryption key, using unencrypted session",
-            exc_info=True,
-        )
-        return TCXSession()
+    return TCXSession()

--- a/specialized_turbo/identification.py
+++ b/specialized_turbo/identification.py
@@ -350,6 +350,17 @@ class TCXIdentification:
     async def run(self) -> IdentificationResult:
         """Execute the full handshake and return an :class:`IdentificationResult`.
 
+        On success the negotiated encrypted :class:`~specialized_turbo.session.
+        TCXSession` **and** the negotiated
+        :class:`~specialized_turbo.wire_profiles.ProtocolRevision` are both
+        installed on the transport before returning, so a caller driving the
+        transport directly (e.g. a Home Assistant client that uses
+        :func:`identify` rather than :class:`~specialized_turbo.connection.
+        SpecializedConnection`) can immediately call
+        :meth:`~specialized_turbo.transport.TCXNotificationTransport.
+        request_bike_parameter` / ``write_bike_parameter`` /
+        ``set_realtime_enabled`` without any further wiring.
+
         Raises a subclass of :class:`IdentificationError` on protocol
         failures, or :class:`~specialized_turbo.transport.
         TCXTransportDisconnectedError` if the link drops mid-handshake.  On
@@ -373,6 +384,10 @@ class TCXIdentification:
             raise
         self._phase = IdentificationPhase.COMPLETE
         self._result = result
+        # Install the negotiated revision on the transport alongside the
+        # session so BikeParameter -> wire id resolution works immediately,
+        # even without a SpecializedConnection.
+        self._transport.protocol_revision = result.protocol_revision
         return result
 
     # -- preconditions ----------------------------------------------------
@@ -555,8 +570,11 @@ async def identify(
 ) -> IdentificationResult:
     """Convenience wrapper: run :class:`TCXIdentification` once.
 
-    The negotiated encrypted session is installed on *transport*; the return
-    value is the structured identification result.  For access to the session
-    or intermediate phase, construct :class:`TCXIdentification` directly.
+    The negotiated encrypted session **and** protocol revision are installed
+    on *transport* before returning, so ``transport.request_bike_parameter``/
+    ``write_bike_parameter``/``set_realtime_enabled`` work immediately; the
+    return value is the structured identification result.  For access to the
+    session or intermediate phase, construct :class:`TCXIdentification`
+    directly.
     """
     return await TCXIdentification(transport, bike_info, key, timeout=timeout).run()

--- a/specialized_turbo/telemetry.py
+++ b/specialized_turbo/telemetry.py
@@ -15,11 +15,13 @@ from typing import Protocol, runtime_checkable
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
+from .bike_info import BikeInfo
 from .connection import SpecializedConnection
 from .coordinator_helpers import TCX_POLL_PARAMS, parse_tcx_wire_payload
 from .framing import is_realtime_packet
+from .keystore.models import BikeEncryptionKey
 from .models import TelemetrySnapshot
-from .protocol import parse_message, parse_tcx_message, ParsedMessage
+from .protocol import BLEProfile, parse_message, parse_tcx_message, ParsedMessage
 from .session import TCXSession
 from .transport import TCXRequestTimeoutError
 from .wire_profiles import ProtocolRevision, UnmappedParameterError
@@ -302,6 +304,9 @@ async def run_telemetry_session(
     address: str,
     *,
     pin: str | None = None,
+    generation: BLEProfile = BLEProfile.TCX,
+    bike_info: BikeInfo | None = None,
+    key: BikeEncryptionKey | None = None,
     duration: float = 0,
     output_format: str = "table",
     output_callback: Callable[[str], None] | None = None,
@@ -310,10 +315,32 @@ async def run_telemetry_session(
     Connect, print telemetry for a while, and return the final snapshot.
 
     Set duration=0 to run until Ctrl+C. output_format is "table" or "json".
+
+    *generation*, *bike_info*, and *key* are forwarded to
+    :class:`SpecializedConnection`. A TCX2+ bike needs the parsed
+    advertisement (*bike_info*) and its AES key (*key*) so the identification
+    handshake can run; a TCU1 bike needs neither -- pass
+    ``generation=BLEProfile.TCU1``. Example::
+
+        # TCX2+ (identified) session
+        await run_telemetry_session(
+            "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
+        )
+
+        # TCU1 session
+        await run_telemetry_session(
+            "DC:DD:BB:4A:D6:55", pin="946166", generation=BLEProfile.TCU1
+        )
     """
     printer = output_callback or print
 
-    async with SpecializedConnection(address, pin=pin) as conn:
+    async with SpecializedConnection(
+        address,
+        pin=pin,
+        generation=generation,
+        bike_info=bike_info,
+        key=key,
+    ) as conn:
         monitor = TelemetryMonitor(conn)
 
         def _on_update(msg: ParsedMessage, snap: TelemetrySnapshot) -> None:

--- a/specialized_turbo/telemetry.py
+++ b/specialized_turbo/telemetry.py
@@ -11,18 +11,42 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Callable
+from typing import Protocol, runtime_checkable
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from .connection import SpecializedConnection
-from .coordinator_helpers import TCX_POLL_PARAMS
+from .coordinator_helpers import TCX_POLL_PARAMS, parse_tcx_wire_payload
 from .framing import is_realtime_packet
 from .models import TelemetrySnapshot
 from .protocol import parse_message, parse_tcx_message, ParsedMessage
 from .session import TCXSession
 from .transport import TCXRequestTimeoutError
+from .wire_profiles import ProtocolRevision
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class RevisionAwareConnection(Protocol):
+    """Narrow interface a connection may satisfy to expose its negotiated
+    TCX protocol revision.
+
+    :class:`TelemetryMonitor` only needs this one read-only property to
+    switch from the legacy enum-ID-assumption parse (:func:`~specialized_turbo
+    .protocol.parse_tcx_message`) to profile-aware (:class:`ProtocolRevision`
+    -> wire id) parsing of TCX notifications. Depending on this narrow
+    structural protocol -- rather than importing a concrete connection
+    type's identification internals -- avoids a circular import with the
+    connection-layer work landing in parallel (identification-driven
+    revision negotiation isn't wired into :class:`SpecializedConnection`
+    yet). A connection that doesn't implement it is treated as
+    "revision unknown" and notification parsing falls back to the legacy
+    path; see :meth:`TelemetryMonitor._active_revision`.
+    """
+
+    @property
+    def active_revision(self) -> ProtocolRevision | None: ...
 
 
 class TelemetryMonitor:
@@ -47,13 +71,20 @@ class TelemetryMonitor:
             await monitor.stop()
     """
 
-    def __init__(self, connection: SpecializedConnection) -> None:
+    def __init__(
+        self,
+        connection: SpecializedConnection,
+        *,
+        revision_accessor: Callable[[], ProtocolRevision | None] | None = None,
+    ) -> None:
         self._conn = connection
+        self._revision_accessor = revision_accessor
         self._snapshot = TelemetrySnapshot()
         self._running = False
         self._queue: asyncio.Queue[ParsedMessage | None] = asyncio.Queue()
         self._nak_count = 0
         self._reported_realtime_bundle = False
+        self._reported_parse_mode = False
         self.on_update: Callable[[ParsedMessage, TelemetrySnapshot], None] | None = None
         """Optional callback invoked after each notification is processed."""
 
@@ -70,6 +101,25 @@ class TelemetryMonitor:
     def nak_count(self) -> int:
         """Number of NAK (rejected) responses received since start."""
         return self._nak_count
+
+    def _active_revision(self) -> ProtocolRevision | None:
+        """Best-effort lookup of the connection's negotiated TCX revision.
+
+        Prefers an injected ``revision_accessor`` (useful for tests, or for
+        callers that don't want their connection type to implement
+        :class:`RevisionAwareConnection` in full); otherwise reads
+        ``connection.active_revision`` via ``getattr`` rather than an
+        ``isinstance`` check, so this keeps working whether or not the
+        connection type structurally satisfies the protocol.
+
+        Returns ``None`` if no revision is available (e.g. the current
+        :class:`SpecializedConnection`, until the parallel connection-layer
+        work exposes ``active_revision``), in which case notification
+        parsing falls back to the legacy, non-profile-aware path.
+        """
+        if self._revision_accessor is not None:
+            return self._revision_accessor()
+        return getattr(self._conn, "active_revision", None)
 
     async def start(self) -> None:
         """Subscribe to bike notifications and begin decoding."""
@@ -117,6 +167,9 @@ class TelemetryMonitor:
             unpacked = session.unpack(data)
             if isinstance(session, TCXSession):
                 if is_realtime_packet(unpacked):
+                    # f8f4 real-time bundles aren't decoded yet -- keep
+                    # suppressing them explicitly rather than misparsing
+                    # their payload as a single field.
                     if not self._reported_realtime_bundle:
                         logger.info(
                             "Receiving bundled TCX real-time data; "
@@ -124,7 +177,26 @@ class TelemetryMonitor:
                         )
                         self._reported_realtime_bundle = True
                     return
-                msg = parse_tcx_message(unpacked)
+                revision = self._active_revision()
+                if revision is not None:
+                    if not self._reported_parse_mode:
+                        logger.info(
+                            "Active TCX revision %s 0x%02x known; "
+                            "parsing notifications profile-aware",
+                            revision.generation.name,
+                            revision.revision,
+                        )
+                        self._reported_parse_mode = True
+                    msg = parse_tcx_wire_payload(unpacked, revision)
+                else:
+                    if not self._reported_parse_mode:
+                        logger.info(
+                            "No active TCX revision available from the "
+                            "connection; parsing notifications with the "
+                            "legacy enum-ID assumption"
+                        )
+                        self._reported_parse_mode = True
+                    msg = parse_tcx_message(unpacked)
             else:
                 msg = parse_message(unpacked)
         except Exception:
@@ -165,7 +237,26 @@ class TelemetryMonitor:
         self._queue.put_nowait(msg)
 
     async def _prime_tcx_snapshot(self) -> None:
-        """Query the initial TCX values through the notification transport."""
+        """Query the initial TCX values through the notification transport.
+
+        Priming still resolves parameters through
+        :class:`SpecializedConnection`'s legacy ``request_tcx_value`` (which
+        assumes wire id == ``BikeParameter`` enum value): the connection
+        layer doesn't yet expose the wire-aware ``TCXNotificationTransport``
+        needed to prime profile-aware via ``coordinator_helpers.poll_tcx``
+        (that lands with the parallel connection-layer work). If the active
+        revision is already known, this is logged clearly so it isn't
+        mistaken for genuine profile-aware priming -- unlike priming, live
+        notification parsing (see ``_notification_handler``) is already
+        profile-aware whenever a revision is available.
+        """
+        if self._active_revision() is not None:
+            logger.info(
+                "TCX protocol revision known, but initial snapshot priming "
+                "is still legacy (enum-ID) until the connection exposes a "
+                "wire-aware transport; live notifications are already "
+                "parsed profile-aware"
+            )
         for param in TCX_POLL_PARAMS:
             try:
                 await self._conn.request_tcx_value(int(param))

--- a/specialized_turbo/telemetry.py
+++ b/specialized_turbo/telemetry.py
@@ -22,14 +22,14 @@ from .models import TelemetrySnapshot
 from .protocol import parse_message, parse_tcx_message, ParsedMessage
 from .session import TCXSession
 from .transport import TCXRequestTimeoutError
-from .wire_profiles import ProtocolRevision
+from .wire_profiles import ProtocolRevision, UnmappedParameterError
 
 logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
 class RevisionAwareConnection(Protocol):
-    """Narrow interface a connection may satisfy to expose its negotiated
+    """Narrow interface a connection exposes to advertise its negotiated
     TCX protocol revision.
 
     :class:`TelemetryMonitor` only needs this one read-only property to
@@ -37,12 +37,12 @@ class RevisionAwareConnection(Protocol):
     .protocol.parse_tcx_message`) to profile-aware (:class:`ProtocolRevision`
     -> wire id) parsing of TCX notifications. Depending on this narrow
     structural protocol -- rather than importing a concrete connection
-    type's identification internals -- avoids a circular import with the
-    connection-layer work landing in parallel (identification-driven
-    revision negotiation isn't wired into :class:`SpecializedConnection`
-    yet). A connection that doesn't implement it is treated as
-    "revision unknown" and notification parsing falls back to the legacy
-    path; see :meth:`TelemetryMonitor._active_revision`.
+    type's identification internals -- keeps the telemetry layer decoupled
+    from the connection layer. :class:`SpecializedConnection` satisfies it
+    via its :attr:`~specialized_turbo.connection.SpecializedConnection.active_revision`
+    property. A connection that doesn't implement it (or returns ``None``)
+    is treated as "revision unknown" and notification parsing falls back to
+    the legacy path; see :meth:`TelemetryMonitor._active_revision`.
     """
 
     @property
@@ -103,7 +103,7 @@ class TelemetryMonitor:
         return self._nak_count
 
     def _active_revision(self) -> ProtocolRevision | None:
-        """Best-effort lookup of the connection's negotiated TCX revision.
+        """Best-effort, type-validated lookup of the connection's negotiated revision.
 
         Prefers an injected ``revision_accessor`` (useful for tests, or for
         callers that don't want their connection type to implement
@@ -112,14 +112,25 @@ class TelemetryMonitor:
         ``isinstance`` check, so this keeps working whether or not the
         connection type structurally satisfies the protocol.
 
-        Returns ``None`` if no revision is available (e.g. the current
-        :class:`SpecializedConnection`, until the parallel connection-layer
-        work exposes ``active_revision``), in which case notification
-        parsing falls back to the legacy, non-profile-aware path.
+        The result is validated: anything other than a
+        :class:`ProtocolRevision` (or ``None``) is rejected with a warning
+        and treated as "revision unknown", so a mistyped accessor or
+        connection attribute can never smuggle a bogus object into the
+        profile-aware wire-id resolution. ``None`` means notification parsing
+        falls back to the legacy, non-profile-aware path.
         """
         if self._revision_accessor is not None:
-            return self._revision_accessor()
-        return getattr(self._conn, "active_revision", None)
+            revision = self._revision_accessor()
+        else:
+            revision = getattr(self._conn, "active_revision", None)
+        if revision is None or isinstance(revision, ProtocolRevision):
+            return revision
+        logger.warning(
+            "Ignoring active_revision of unexpected type %s (expected "
+            "ProtocolRevision or None); falling back to legacy parsing",
+            type(revision).__name__,
+        )
+        return None
 
     async def start(self) -> None:
         """Subscribe to bike notifications and begin decoding."""
@@ -239,31 +250,50 @@ class TelemetryMonitor:
     async def _prime_tcx_snapshot(self) -> None:
         """Query the initial TCX values through the notification transport.
 
-        Priming still resolves parameters through
-        :class:`SpecializedConnection`'s legacy ``request_tcx_value`` (which
-        assumes wire id == ``BikeParameter`` enum value): the connection
-        layer doesn't yet expose the wire-aware ``TCXNotificationTransport``
-        needed to prime profile-aware via ``coordinator_helpers.poll_tcx``
-        (that lands with the parallel connection-layer work). If the active
-        revision is already known, this is logged clearly so it isn't
-        mistaken for genuine profile-aware priming -- unlike priming, live
-        notification parsing (see ``_notification_handler``) is already
-        profile-aware whenever a revision is available.
+        Profile-aware: each :data:`TCX_POLL_PARAMS` entry is requested via
+        :meth:`SpecializedConnection.request_tcx_parameter`, which resolves
+        the app-level ``BikeParameter`` to a wire command id through the
+        negotiated :class:`ProtocolRevision` -- the same revision the live
+        ``_notification_handler`` uses to decode responses. The request and
+        notification sides therefore switch together: when a revision is
+        available both are profile-aware; when it is not, priming is skipped
+        entirely (the deprecated raw enum-ID path is never used) and the
+        snapshot is populated by live notifications alone.
+
+        Per-parameter failures are contained: a parameter with no wire id
+        for this revision is skipped; a request timeout stops priming
+        (matching the previous behaviour) without aborting ``start()``.
         """
-        if self._active_revision() is not None:
+        revision = self._active_revision()
+        if revision is None:
             logger.info(
-                "TCX protocol revision known, but initial snapshot priming "
-                "is still legacy (enum-ID) until the connection exposes a "
-                "wire-aware transport; live notifications are already "
-                "parsed profile-aware"
+                "No active TCX protocol revision available; skipping initial "
+                "snapshot priming (cannot address parameters by wire id "
+                "without a negotiated revision). Live notifications will "
+                "populate the snapshot as they arrive."
             )
+            return
+        logger.info(
+            "Priming TCX snapshot profile-aware (BikeParameter -> wire id) "
+            "for %s revision 0x%02x",
+            revision.generation.name,
+            revision.revision,
+        )
         for param in TCX_POLL_PARAMS:
             try:
-                await self._conn.request_tcx_value(int(param))
+                await self._conn.request_tcx_parameter(param)
+            except UnmappedParameterError:
+                logger.debug(
+                    "No wire id for %s on %s revision 0x%02x; skipping prime",
+                    param.name,
+                    revision.generation.name,
+                    revision.revision,
+                )
+                continue
             except TCXRequestTimeoutError:
                 logger.warning(
-                    "Timed out while priming TCX telemetry at parameter %d",
-                    int(param),
+                    "Timed out while priming TCX telemetry at parameter %s",
+                    param.name,
                 )
                 break
 

--- a/specialized_turbo/transport.py
+++ b/specialized_turbo/transport.py
@@ -13,7 +13,7 @@ from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from .framing import is_nak_packet, parse_nak_packet
-from .parameters import decode_parameter_id, encode_parameter_id
+from .parameters import BikeParameter, decode_parameter_id, encode_parameter_id
 from .protocol import (
     BLEProfile,
     BLEServiceID,
@@ -21,6 +21,7 @@ from .protocol import (
     get_service_characteristics,
 )
 from .session import TCXSession
+from .wire_profiles import ProtocolRevision, wire_id_for
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,26 @@ class TCXTransportDisconnectedError(ConnectionError):
     """Raised when the BLE link closes during a TCX transaction."""
 
 
+class TCXProtocolNotNegotiatedError(RuntimeError):
+    """Raised when a ``BikeParameter`` is addressed before identification.
+
+    Resolving a :class:`~specialized_turbo.parameters.BikeParameter` to a
+    wire command id requires the :class:`~specialized_turbo.wire_profiles.
+    ProtocolRevision` negotiated during identification (see
+    :class:`~specialized_turbo.identification.TCXIdentification`).  This is
+    raised instead of guessing or silently reusing the ``BikeParameter``
+    value as if it were a wire id.
+    """
+
+    def __init__(self, param: BikeParameter) -> None:
+        super().__init__(
+            f"Cannot resolve {param.name} to a wire id: no TCX protocol "
+            "revision has been negotiated yet (identification must "
+            "complete first)"
+        )
+        self.param = param
+
+
 @dataclass(slots=True)
 class _PendingRequest:
     wire_id: int
@@ -93,6 +114,7 @@ class TCXNotificationTransport:
         self._pending: _PendingRequest | None = None
         self._request_lock = asyncio.Lock()
         self._disconnected = False
+        self._protocol_revision: ProtocolRevision | None = None
 
     @property
     def session(self) -> TCXSession:
@@ -102,6 +124,23 @@ class TCXNotificationTransport:
     @session.setter
     def session(self, session: TCXSession) -> None:
         self._session = session
+
+    @property
+    def protocol_revision(self) -> ProtocolRevision | None:
+        """Generation/revision negotiated by a completed identification handshake.
+
+        ``None`` until :class:`~specialized_turbo.identification.
+        TCXIdentification` has completed and the connection layer installs
+        the negotiated :class:`~specialized_turbo.wire_profiles.
+        ProtocolRevision` here. Consumers should treat this as read-only;
+        it is set once, by the connection layer, immediately after a
+        successful identification.
+        """
+        return self._protocol_revision
+
+    @protocol_revision.setter
+    def protocol_revision(self, revision: ProtocolRevision) -> None:
+        self._protocol_revision = revision
 
     def add_listener(self, callback: NotificationCallback) -> None:
         """Forward incoming notifications to *callback*."""
@@ -212,25 +251,77 @@ class TCXNotificationTransport:
         """
         return await self.request_wire_parameter(param_id, timeout=timeout)
 
+    def _resolve_wire_id(self, param: BikeParameter) -> int:
+        """Resolve *param* to a wire id through the negotiated protocol revision.
+
+        Raises:
+            TCXProtocolNotNegotiatedError: identification hasn't completed
+                yet, so no :class:`~specialized_turbo.wire_profiles.
+                ProtocolRevision` is installed.
+        """
+        revision = self._protocol_revision
+        if revision is None:
+            raise TCXProtocolNotNegotiatedError(param)
+        return wire_id_for(param, revision.generation, revision.revision)
+
+    async def request_bike_parameter(
+        self,
+        param: BikeParameter,
+        *,
+        timeout: float | None = None,
+    ) -> bytes:
+        """Read a TCX2+ value by its stable app-level ``BikeParameter`` id.
+
+        Resolves *param* to a wire command id through the
+        :class:`~specialized_turbo.wire_profiles.ProtocolRevision`
+        negotiated during identification (see :attr:`protocol_revision`),
+        then correlates the response by that wire id -- this is the
+        profile-aware replacement for passing a raw wire id (or a
+        ``BikeParameter`` value that coincidentally matches one) directly
+        to :meth:`request_parameter`/:meth:`request_wire_parameter`.
+        """
+        wire_id = self._resolve_wire_id(param)
+        return await self.request_wire_parameter(wire_id, timeout=timeout)
+
     async def write_parameter(
         self,
         param_id: int,
         data: bytes | bytearray,
     ) -> None:
-        """Write a parameter on service 3 without waiting for a GATT response."""
+        """Write to a wire command id on service 3 without a GATT response.
+
+        .. deprecated::
+           Treats *param_id* directly as the wire id. New code addressing a
+           :class:`~specialized_turbo.parameters.BikeParameter` should use
+           :meth:`write_bike_parameter`, which resolves the wire id through
+           the negotiated protocol revision instead of assuming the two id
+           spaces coincide.
+        """
         payload = build_tcx_write(param_id, data)
         await self.write_frame(
             BLEServiceID.DATA,
             self._session.pack(payload),
         )
 
+    async def write_bike_parameter(
+        self,
+        param: BikeParameter,
+        data: bytes | bytearray,
+    ) -> None:
+        """Write a TCX2+ value by its stable app-level ``BikeParameter`` id.
+
+        Resolves *param* to a wire command id through the negotiated
+        :attr:`protocol_revision` before writing -- the profile-aware
+        replacement for :meth:`write_parameter`.
+        """
+        wire_id = self._resolve_wire_id(param)
+        await self.write_parameter(wire_id, data)
+
     async def set_realtime_enabled(self, enabled: bool) -> None:
         """Enable or disable the bike's real-time telemetry stream."""
-        from .parameters import BikeParameter
-
         await self.subscribe_for_realtime()
-        await self.write_parameter(
-            int(BikeParameter.SYSTEM_REAL_TIME_DATA_ENB),
+        await self.write_bike_parameter(
+            BikeParameter.SYSTEM_REAL_TIME_DATA_ENB,
             bytes([enabled]),
         )
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,6 +13,7 @@ would.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -22,7 +23,10 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 
 import specialized_turbo.connection as connection_module
 from specialized_turbo.bike_info import BikeInfo
-from specialized_turbo.connection import SpecializedConnection
+from specialized_turbo.connection import (
+    SpecializedConnection,
+    UnsupportedTCXOperationError,
+)
 from specialized_turbo.framing import is_nak_packet
 from specialized_turbo.identification import (
     IncompleteBikeInfoError,
@@ -640,8 +644,34 @@ async def test_tcu1_request_read_is_unchanged(
     await connection.disconnect()
 
 
+@pytest.mark.asyncio
+async def test_tcu1_convenience_writes_unchanged(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    """TCU1 convenience writers keep the bare sender/channel/value format."""
+    connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF",
+        generation=BLEProfile.TCU1,
+    )
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
+
+    await connection.set_assist_level(2)
+    assert client.writes[-1][1] == bytes([0x01, 0x05, 0x02])
+
+    await connection.set_assist_percentage(1, 60)  # TRAIL -> channel 0x04
+    assert client.writes[-1][1] == bytes([0x02, 0x04, 60])
+
+    await connection.set_shuttle(50)  # TCU1 supports shuttle
+    assert client.writes[-1][1] == bytes([0x01, 0x15, 50])
+
+    await connection.disconnect()
+
+
 # ---------------------------------------------------------------------------
-# TelemetryMonitor still primes without GATT reads (legacy raw-wire path).
+# TelemetryMonitor primes profile-aware (no GATT reads); the connection's
+# active_revision drives both priming and live notification decoding.
 # ---------------------------------------------------------------------------
 
 
@@ -661,6 +691,150 @@ async def test_telemetry_monitor_primes_tcx_snapshot_without_reads(
     assert client.reads == []
 
     await monitor.stop()
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_active_revision_aliases_protocol_revision(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = _connection()
+    await connection.connect()
+
+    expected = ProtocolRevision(GENERATION, REVISION)
+    assert connection.active_revision == expected
+    # protocol_revision is retained as an alias of the canonical accessor.
+    assert connection.protocol_revision == connection.active_revision
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_primes_and_decodes_soc_profile_aware(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    """AES connect -> active revision -> mapped priming + notification (SOC 0x0500)."""
+    connection = _connection()
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
+    monitor = TelemetryMonitor(connection)
+
+    # The monitor reads the connection's negotiated revision structurally.
+    assert monitor._active_revision() == ProtocolRevision(GENERATION, REVISION)
+
+    await monitor.start()
+
+    # Priming addressed SOC by its real wire id 0x0500 -- never the raw enum
+    # id (26), which is not a valid TCX2 wire id.
+    assert 0x0500 in client.bike.requests
+    assert int(BikeParameter.BATTERY1_STATE_OF_CHARGE) not in client.bike.requests
+    # The healthy bike's primed SOC body is 49.
+    assert monitor.snapshot.battery.charge_pct == 49
+
+    # A live SOC notification (wire 0x0500 = 61) decodes profile-aware.
+    packet = connection.session.pack(encode_parameter_id(0x0500) + bytes([61]))
+    client.notify(BLEServiceID.DATA, packet)
+    assert monitor.snapshot.battery.charge_pct == 61
+    assert client.reads == []
+
+    await monitor.stop()
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_no_deprecated_raw_calls_during_connect_and_telemetry(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    """Connect + prime + decode must not touch the deprecated raw enum-id path."""
+    connection = _connection()
+    monitor = TelemetryMonitor(connection)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        await connection.connect()
+        await monitor.start()
+        client = fake_bleak.instance
+        assert client is not None
+        packet = connection.session.pack(encode_parameter_id(0x0500) + bytes([61]))
+        client.notify(BLEServiceID.DATA, packet)
+        await monitor.stop()
+
+    assert monitor.snapshot.battery.charge_pct == 61
+    await connection.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# TCX convenience writers map through the correct BikeParameter wire ids.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tcx_convenience_writes_map_to_wire_ids(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = _connection()
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
+    data_service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.DATA)
+
+    def last_data_write() -> bytes:
+        characteristic, packet, response = client.writes[-1]
+        assert characteristic == data_service.write
+        assert response is False
+        return connection.session.unpack(packet)
+
+    # assist level -> MOTOR_ACTIVE_TRAVEL_MODE (0x07fa)
+    await connection.set_assist_level(2)
+    assert last_data_write()[:3] == bytes([0x07, 0xFA, 0x02])
+
+    # profile scaling ECO/TRAIL/TURBO -> 0x07f2 / 0x07f1 / 0x07f0
+    await connection.set_assist_percentage(0, 55)
+    assert last_data_write()[:3] == bytes([0x07, 0xF2, 55])
+    await connection.set_assist_percentage(1, 60)
+    assert last_data_write()[:3] == bytes([0x07, 0xF1, 60])
+    await connection.set_assist_percentage(2, 70)
+    assert last_data_write()[:3] == bytes([0x07, 0xF0, 70])
+
+    # acceleration -> MOTOR_ACCELERATION_RESPONSE (0x0711); 50% -> 6000 LE
+    await connection.set_acceleration(50)
+    unpacked = last_data_write()
+    assert unpacked[:2] == bytes([0x07, 0x11])
+    assert unpacked[2:4] == (6000).to_bytes(2, "little")
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_tcx_set_shuttle_raises_unsupported(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = _connection()
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
+    writes_before = len(client.writes)
+
+    with pytest.raises(UnsupportedTCXOperationError, match="shuttle"):
+        await connection.set_shuttle(50)
+
+    # No wire write was emitted for the unsupported operation.
+    assert len(client.writes) == writes_before
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_tcx_set_assist_percentage_rejects_bad_level_index(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = _connection()
+    await connection.connect()
+
+    with pytest.raises(ValueError, match="level_index"):
+        await connection.set_assist_percentage(3, 50)
+
     await connection.disconnect()
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,27 +1,79 @@
-"""Connection-level tests for TCX write/notification transactions."""
+"""Connection-level tests for TCX identification/session/key integration.
+
+The fake BLE client below plays the role of a real, AES-encrypted TCX2 bike:
+it answers the seven-step identification handshake exactly like the fake
+bike in ``test_identification.py`` (clear ``GET_NEW_VI``/
+``HMI_PROTOCOL_VERSION`` control frames, then AES-CTR encrypted reads for
+every other step), then continues encrypting/decrypting every subsequent
+request through the same negotiated session -- so post-identification reads
+(SOC, real-time enable, ...) exercise the exact crypto path a real bike
+would.
+"""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 import pytest
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 import specialized_turbo.connection as connection_module
+from specialized_turbo.bike_info import BikeInfo
 from specialized_turbo.connection import SpecializedConnection
-from specialized_turbo.framing import is_nak_packet, pack_tcx, unpack_tcx
+from specialized_turbo.framing import is_nak_packet
+from specialized_turbo.identification import (
+    IncompleteBikeInfoError,
+    MissingEncryptionKeyError,
+    UnsupportedGenerationError,
+)
+from specialized_turbo.keystore.models import BikeEncryptionKey
+from specialized_turbo.parameters import BikeParameter, encode_parameter_id
 from specialized_turbo.protocol import (
     BLEProfile,
     BLEServiceID,
     get_service_characteristics,
 )
+from specialized_turbo.session import TCU1Session, TCXSession
 from specialized_turbo.telemetry import TelemetryMonitor
 from specialized_turbo.transport import (
     NotificationCallback,
     TCXTransportDisconnectedError,
 )
+from specialized_turbo.wire_profiles import ProtocolRevision, TCXGeneration, wire_id_for
+
+# Deterministic synthetic key + IV -- never real key material.
+KEY_RAW = b"\x33" * 16
+WRONG_KEY_RAW = b"\x99" * 16
+IV = b"\x44" * 16
+
+GENERATION = TCXGeneration.TCX2
+REVISION = 0x12
+USB_REVISION = 0x03
+
+WIRE_GET_NEW_VI = 0x0A00
+WIRE_PROTOCOL_VERSION = 0x0A01
+
+
+def _wire(param: BikeParameter, revision: int | None = REVISION) -> int:
+    return wire_id_for(param, GENERATION, revision)
+
+
+def _complete_bike_info(
+    generation: TCXGeneration | None = GENERATION, *, complete: bool = True
+) -> BikeInfo:
+    return BikeInfo(
+        name="SPECIALIZED",
+        bike_name="LEVO2 SPECIALIZED",
+        is_bike=True,
+        complete=complete,
+        hmi_serial="1234",
+        hmi_hardware_version="B.3.3",
+        ble_profile=BLEProfile.TCX,
+        tcx_generation=generation,
+    )
 
 
 @dataclass
@@ -29,7 +81,62 @@ class _FakeCharacteristic:
     uuid: str
 
 
+@dataclass
+class _FakeBike:
+    """Answers wire requests like a real AES-CTR encrypted TCX2 bike.
+
+    Every identification step is pre-programmed via ``_healthy_bike()``.
+    Any *other* wire id gets a generic ``[wire_id_be, 0x01]`` reply (still
+    encrypted through the same session) -- enough for legacy raw-wire-id
+    callers (``request_tcx_value``/``TelemetryMonitor``) without needing to
+    special-case every parameter.
+    """
+
+    key: bytes = KEY_RAW
+    iv: bytes = IV
+    _session: TCXSession = field(init=False)
+    _bodies: dict[int, bytes] = field(default_factory=dict, init=False)
+    _naks: dict[int, int] = field(default_factory=dict, init=False)
+    requests: list[int] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        self._session = TCXSession(key=self.key, iv=self.iv)
+
+    def set_body(self, wire_id: int, body: bytes) -> None:
+        self._bodies[wire_id] = encode_parameter_id(wire_id) + bytes(body)
+
+    def set_nak(self, wire_id: int, reason: int) -> None:
+        self._naks[wire_id] = reason
+
+    def reply_for(self, wire_id: int) -> bytes:
+        self.requests.append(wire_id)
+        if wire_id in self._naks:
+            nak = (
+                b"\xf8\xff"
+                + encode_parameter_id(wire_id)
+                + bytes([self._naks[wire_id]])
+            )
+            return self._session.pack(nak)
+        body = self._bodies.get(wire_id, encode_parameter_id(wire_id) + b"\x01")
+        return self._session.pack(body)
+
+
+def _healthy_bike() -> _FakeBike:
+    bike = _FakeBike()
+    bike.set_body(WIRE_GET_NEW_VI, IV)
+    bike.set_body(WIRE_PROTOCOL_VERSION, bytes([REVISION, USB_REVISION]))
+    bike.set_body(_wire(BikeParameter.SYSTEM_STATE), bytes([4]))
+    bike.set_body(_wire(BikeParameter.BATTERY1_FIRMWARE), bytes([1, 2, 3]))
+    bike.set_body(_wire(BikeParameter.SYSTEM_HMI_HW_VERSION), b"B.3.3")
+    bike.set_body(_wire(BikeParameter.SYSTEM_MOTOR_TYPE), bytes([7]))
+    bike.set_body(_wire(BikeParameter.SYSTEM_EBIKE_SERIAL_NUMBER), b"SN12345")
+    bike.set_body(_wire(BikeParameter.BATTERY1_STATE_OF_CHARGE), bytes([49]))
+    return bike
+
+
 class _FakeBleakClient:
+    """A fake ``BleakClient`` fronting a :class:`_FakeBike`."""
+
     instance: _FakeBleakClient | None = None
 
     def __init__(
@@ -45,8 +152,13 @@ class _FakeBleakClient:
         self.subscriptions: list[str] = []
         self.writes: list[tuple[str, bytes, bool | None]] = []
         self.reads: list[str] = []
-        self.read_response = bytes.fromhex("000c31")
-        self.disconnect_on_param: int | None = None
+        self.bike = _healthy_bike()
+        # If set, disconnect (and stop answering) as soon as this wire id
+        # is written -- simulates a mid-handshake link drop.
+        self.disconnect_on_wire: int | None = None
+        # Characteristic UUIDs for which start_notify() should raise --
+        # simulates a post-identification subscribe_for_realtime() failure.
+        self.fail_start_notify_for: set[str] = set()
 
     async def connect(self) -> None:
         self.is_connected = True
@@ -62,15 +174,17 @@ class _FakeBleakClient:
         characteristic: str,
         callback: NotificationCallback,
     ) -> None:
+        if characteristic in self.fail_start_notify_for:
+            raise RuntimeError(f"start_notify failed for {characteristic}")
         self.callbacks[characteristic] = callback
         self.subscriptions.append(characteristic)
 
     async def stop_notify(self, characteristic: str) -> None:
-        self.callbacks.pop(characteristic)
+        self.callbacks.pop(characteristic, None)
 
     async def read_gatt_char(self, characteristic: str) -> bytes:
         self.reads.append(characteristic)
-        return self.read_response
+        return b"\x00\x0c\x31"
 
     async def write_gatt_char(
         self,
@@ -81,51 +195,30 @@ class _FakeBleakClient:
         packet = bytes(data)
         self.writes.append((characteristic, packet, response))
 
-        if len(packet) == 20:
-            param_id = int.from_bytes(unpack_tcx(packet)[:2], "big")
-            if param_id == self.disconnect_on_param:
-                self.is_connected = False
-                if self.disconnected_callback is not None:
-                    self.disconnected_callback(self)
-                return
+        if len(packet) != 20:
+            return
+        wire_id = int.from_bytes(packet[:2], "big")
 
-        request_service = get_service_characteristics(
-            BLEProfile.TCX,
-            BLEServiceID.REQUEST,
-        )
-        if characteristic != request_service.write or len(packet) != 20:
+        if wire_id == self.disconnect_on_wire:
+            self.is_connected = False
+            if self.disconnected_callback is not None:
+                self.disconnected_callback(self)
             return
 
-        if param_id == 14:
-            reply = pack_tcx(bytes.fromhex("f8ff000e05"))
-        elif param_id == 26:
-            reply = pack_tcx(bytes.fromhex("001a31"))
-        else:
-            reply = pack_tcx(param_id.to_bytes(2, "big") + b"\x01")
+        request_service = get_service_characteristics(
+            BLEProfile.TCX, BLEServiceID.REQUEST
+        )
+        if characteristic != request_service.write:
+            return
+
+        reply = self.bike.reply_for(wire_id)
         self.notify(BLEServiceID.REQUEST, reply)
 
     def notify(self, service_id: BLEServiceID, data: bytes) -> None:
         uuid = get_service_characteristics(BLEProfile.TCX, service_id).notify
         callback = self.callbacks[uuid]
-        characteristic = cast(
-            BleakGATTCharacteristic,
-            _FakeCharacteristic(uuid),
-        )
+        characteristic = cast(BleakGATTCharacteristic, _FakeCharacteristic(uuid))
         callback(characteristic, bytearray(data))
-
-
-class _DisconnectingBleakClient(_FakeBleakClient):
-    def __init__(
-        self,
-        address: object,
-        *,
-        disconnected_callback: Callable[[Any], None] | None = None,
-    ) -> None:
-        super().__init__(
-            address,
-            disconnected_callback=disconnected_callback,
-        )
-        self.disconnect_on_param = 300
 
 
 @pytest.fixture
@@ -134,11 +227,26 @@ def fake_bleak(monkeypatch: pytest.MonkeyPatch) -> type[_FakeBleakClient]:
     return _FakeBleakClient
 
 
+def _connection(**kwargs: Any) -> SpecializedConnection:
+    return SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF",
+        bike_info=_complete_bike_info(),
+        key=BikeEncryptionKey(raw=KEY_RAW),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Successful AES connect: identification, session/revision installed,
+# S2/S3 subscribed only after success, zero GATT reads.
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_tcx_connect_identifies_without_gatt_reads(
     fake_bleak: type[_FakeBleakClient],
 ) -> None:
-    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    connection = _connection()
 
     await connection.connect()
 
@@ -156,51 +264,71 @@ async def test_tcx_connect_identifies_without_gatt_reads(
     ]
     assert client.subscriptions == expected_subscriptions
 
-    identification = [unpack_tcx(packet) for _, packet, _ in client.writes[:7]]
-    assert [int.from_bytes(packet[:2], "big") for packet in identification] == [
-        300,
-        310,
-        363,
-        14,
-        308,
-        329,
-        290,
+    identification_wire_ids = [
+        int.from_bytes(packet[:2], "big") for _, packet, _ in client.writes[:7]
+    ]
+    assert identification_wire_ids == [
+        WIRE_GET_NEW_VI,
+        WIRE_PROTOCOL_VERSION,
+        _wire(BikeParameter.SYSTEM_STATE),
+        _wire(BikeParameter.BATTERY1_FIRMWARE),
+        _wire(BikeParameter.SYSTEM_HMI_HW_VERSION),
+        _wire(BikeParameter.SYSTEM_MOTOR_TYPE),
+        _wire(BikeParameter.SYSTEM_EBIKE_SERIAL_NUMBER),
     ]
     assert all(response is False for _, _, response in client.writes[:7])
-    assert all(not is_nak_packet(packet) for packet in identification)
+    assert all(not is_nak_packet(packet) for _, packet, _ in client.writes[:7])
 
     await connection.disconnect()
 
 
 @pytest.mark.asyncio
-async def test_disconnect_during_identification_fails_cleanly(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_successful_identification_installs_session_and_revision(
+    fake_bleak: type[_FakeBleakClient],
 ) -> None:
-    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
-    monkeypatch.setattr(
-        connection_module,
-        "BleakClient",
-        _DisconnectingBleakClient,
+    connection = _connection()
+
+    await connection.connect()
+
+    assert isinstance(connection.session, TCXSession)
+    assert connection.session.encrypted
+    assert connection.protocol_revision == ProtocolRevision(GENERATION, REVISION)
+    assert connection.identification_result is not None
+    assert (
+        connection.identification_result.protocol_revision
+        == connection.protocol_revision
     )
 
-    with pytest.raises(TCXTransportDisconnectedError, match="disconnected"):
-        await connection.connect()
-
-    assert not connection.is_connected
+    await connection.disconnect()
 
 
 @pytest.mark.asyncio
-async def test_tcx_read_and_stream_control_use_notifications(
+async def test_soc_reads_wire_0500_through_negotiated_revision(
     fake_bleak: type[_FakeBleakClient],
 ) -> None:
-    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    connection = _connection()
     await connection.connect()
     client = fake_bleak.instance
     assert client is not None
 
-    message = await connection.request_tcx_value(26)
-    assert message.converted_value == 49
+    msg = await connection.request_tcx_parameter(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+
+    assert msg.wire_id == 0x0500
+    assert msg.value == 49
+    assert client.bike.requests[-1] == 0x0500
     assert client.reads == []
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_realtime_enable_uses_wire_080f(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = _connection()
+    await connection.connect()
+    client = fake_bleak.instance
+    assert client is not None
 
     received: list[bytes] = []
 
@@ -215,18 +343,250 @@ async def test_tcx_read_and_stream_control_use_notifications(
     data_service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.DATA)
     enable_characteristic, enable_packet, enable_response = client.writes[-1]
     assert enable_characteristic == data_service.write
-    assert unpack_tcx(enable_packet)[:3] == bytes.fromhex("015a01")
+    assert connection.session.unpack(enable_packet)[:3] == bytes.fromhex("080f01")
     assert enable_response is False
-
-    telemetry_packet = pack_tcx(bytes.fromhex("001a31"))
-    client.notify(BLEServiceID.REQUEST, telemetry_packet)
-    assert received == [telemetry_packet]
 
     await connection.unsubscribe_notifications()
     disable_characteristic, disable_packet, disable_response = client.writes[-1]
     assert disable_characteristic == data_service.write
-    assert unpack_tcx(disable_packet)[:3] == bytes.fromhex("015a00")
+    assert connection.session.unpack(disable_packet)[:3] == bytes.fromhex("080f00")
     assert disable_response is False
+
+    await connection.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Missing / incomplete bike info and key -- clean, typed errors.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_bike_info_raises_cleanly(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF", key=BikeEncryptionKey(raw=KEY_RAW)
+    )
+
+    with pytest.raises(IncompleteBikeInfoError):
+        await connection.connect()
+
+    assert not connection.is_connected
+    assert connection.protocol_revision is None
+
+    # Retryable: connecting again (still without bike_info) fails the same
+    # clean way, with no leftover state or AttributeError.
+    with pytest.raises(IncompleteBikeInfoError):
+        await connection.connect()
+    assert not connection.is_connected
+
+
+@pytest.mark.asyncio
+async def test_incomplete_bike_info_raises_cleanly(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF",
+        bike_info=_complete_bike_info(complete=False),
+        key=BikeEncryptionKey(raw=KEY_RAW),
+    )
+
+    with pytest.raises(IncompleteBikeInfoError):
+        await connection.connect()
+
+    assert not connection.is_connected
+
+
+@pytest.mark.asyncio
+async def test_missing_generation_raises_cleanly(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF",
+        bike_info=_complete_bike_info(generation=None),
+        key=BikeEncryptionKey(raw=KEY_RAW),
+    )
+
+    with pytest.raises(UnsupportedGenerationError):
+        await connection.connect()
+
+    assert not connection.is_connected
+
+
+@pytest.mark.asyncio
+async def test_missing_key_raises_cleanly_and_is_retryable(
+    fake_bleak: type[_FakeBleakClient],
+) -> None:
+    connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF", bike_info=_complete_bike_info()
+    )
+
+    with pytest.raises(MissingEncryptionKeyError):
+        await connection.connect()
+    assert not connection.is_connected
+
+    # Retry with a valid key on the *same* connection object succeeds.
+    connection._key = BikeEncryptionKey(raw=KEY_RAW)  # noqa: SLF001
+    await connection.connect()
+    assert connection.is_connected
+    assert connection.protocol_revision == ProtocolRevision(GENERATION, REVISION)
+
+    await connection.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# NAK during identification.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nak_during_identification_fails_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _connection()
+
+    class _NakkingClient(_FakeBleakClient):
+        def __init__(
+            self,
+            address: object,
+            *,
+            disconnected_callback: Callable[[Any], None] | None = None,
+        ) -> None:
+            super().__init__(address, disconnected_callback=disconnected_callback)
+            self.bike = _healthy_bike()
+            self.bike.set_nak(_wire(BikeParameter.SYSTEM_STATE), 0x05)
+
+    monkeypatch.setattr(connection_module, "BleakClient", _NakkingClient)
+
+    with pytest.raises(Exception, match="0x05|reason"):
+        await connection.connect()
+
+    assert not connection.is_connected
+    assert connection.protocol_revision is None
+
+
+# ---------------------------------------------------------------------------
+# Disconnect mid-identification: clean failure, retryable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_identification_fails_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _connection()
+
+    # Configure the disconnect trigger *before* connect() creates the client
+    # by patching the constructor via a thin subclass.
+    class _DisconnectingClient(_FakeBleakClient):
+        def __init__(
+            self,
+            address: object,
+            *,
+            disconnected_callback: Callable[[Any], None] | None = None,
+        ) -> None:
+            super().__init__(address, disconnected_callback=disconnected_callback)
+            self.disconnect_on_wire = WIRE_GET_NEW_VI
+
+    monkeypatch.setattr(connection_module, "BleakClient", _DisconnectingClient)
+
+    with pytest.raises(TCXTransportDisconnectedError, match="disconnected"):
+        await connection.connect()
+
+    assert not connection.is_connected
+    assert connection.protocol_revision is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_identification_allows_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _connection()
+
+    class _DisconnectingClient(_FakeBleakClient):
+        def __init__(
+            self,
+            address: object,
+            *,
+            disconnected_callback: Callable[[Any], None] | None = None,
+        ) -> None:
+            super().__init__(address, disconnected_callback=disconnected_callback)
+            self.disconnect_on_wire = WIRE_GET_NEW_VI
+
+    monkeypatch.setattr(connection_module, "BleakClient", _DisconnectingClient)
+    with pytest.raises(TCXTransportDisconnectedError):
+        await connection.connect()
+    assert not connection.is_connected
+
+    # A healthy client this time -- retry succeeds cleanly.
+    monkeypatch.setattr(connection_module, "BleakClient", _FakeBleakClient)
+    await connection.connect()
+    assert connection.is_connected
+    assert connection.protocol_revision == ProtocolRevision(GENERATION, REVISION)
+
+    await connection.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_realtime_subscribe_failure_after_identification_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-identification failure (S3/S2 subscribe) must not leak state.
+
+    Identification itself succeeds (all seven steps complete), but
+    ``subscribe_for_realtime()`` -- the DATA/COMMAND ``start_notify()`` calls
+    made only *after* a successful handshake -- then fails. ``connect()``
+    must run the same cleanup as an identification failure: disconnect and
+    drop the old client/transport, clear session/revision/result, and leave
+    ``is_connected`` false so a subsequent connect() can retry cleanly.
+    """
+    connection = _connection()
+    data_service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.DATA)
+    request_service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.REQUEST)
+
+    class _RealtimeSubscribeFailingClient(_FakeBleakClient):
+        def __init__(
+            self,
+            address: object,
+            *,
+            disconnected_callback: Callable[[Any], None] | None = None,
+        ) -> None:
+            super().__init__(address, disconnected_callback=disconnected_callback)
+            self.fail_start_notify_for = {data_service.notify}
+
+    monkeypatch.setattr(
+        connection_module, "BleakClient", _RealtimeSubscribeFailingClient
+    )
+
+    with pytest.raises(RuntimeError, match="start_notify failed"):
+        await connection.connect()
+
+    failed_client = _RealtimeSubscribeFailingClient.instance
+    assert failed_client is not None
+    # Identification (all 7 steps) completed before the DATA subscribe blew
+    # up -- no extra/leaked writes, and only the identification-phase
+    # (REQUEST) notification stayed subscribed on the old, now-abandoned
+    # client.
+    assert len(failed_client.writes) == 7
+    assert failed_client.subscriptions == [request_service.notify]
+
+    # No leaked old client/transport/profile: is_connected is false and the
+    # negotiated state is fully cleared, not half-installed.
+    assert not connection.is_connected
+    assert connection.protocol_revision is None
+    assert connection.identification_result is None
+    assert isinstance(connection.session, TCU1Session)
+
+    # A healthy retry (fresh client) succeeds cleanly and doesn't reuse
+    # anything from the failed attempt.
+    monkeypatch.setattr(connection_module, "BleakClient", _FakeBleakClient)
+    await connection.connect()
+    healthy_client = _FakeBleakClient.instance
+    assert healthy_client is not None
+    assert healthy_client is not failed_client
+    assert connection.is_connected
+    assert connection.protocol_revision == ProtocolRevision(GENERATION, REVISION)
+    assert connection.identification_result is not None
 
     await connection.disconnect()
 
@@ -235,7 +595,7 @@ async def test_tcx_read_and_stream_control_use_notifications(
 async def test_disconnect_during_unsubscribe_does_not_race_transport_cleanup(
     fake_bleak: type[_FakeBleakClient],
 ) -> None:
-    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    connection = _connection()
     await connection.connect()
     client = fake_bleak.instance
     assert client is not None
@@ -247,11 +607,16 @@ async def test_disconnect_during_unsubscribe_does_not_race_transport_cleanup(
         pass
 
     await connection.subscribe_notifications(notification)
-    client.disconnect_on_param = 346
+    client.disconnect_on_wire = 0x080F  # real-time disable write
 
     await connection.unsubscribe_notifications()
 
     assert not connection.is_connected
+
+
+# ---------------------------------------------------------------------------
+# TCU1 unchanged.
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -275,11 +640,16 @@ async def test_tcu1_request_read_is_unchanged(
     await connection.disconnect()
 
 
+# ---------------------------------------------------------------------------
+# TelemetryMonitor still primes without GATT reads (legacy raw-wire path).
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_telemetry_monitor_primes_tcx_snapshot_without_reads(
     fake_bleak: type[_FakeBleakClient],
 ) -> None:
-    connection = SpecializedConnection("AA:BB:CC:DD:EE:FF")
+    connection = _connection()
     await connection.connect()
     client = fake_bleak.instance
     assert client is not None
@@ -287,16 +657,46 @@ async def test_telemetry_monitor_primes_tcx_snapshot_without_reads(
 
     await monitor.start()
 
-    assert monitor.snapshot.battery.charge_pct == 49
     assert monitor.snapshot.message_count > 0
     assert client.reads == []
 
-    message_count = monitor.snapshot.message_count
-    client.notify(
-        BLEServiceID.DATA,
-        pack_tcx(bytes.fromhex("f8f4ff001a31")),
-    )
-    assert monitor.snapshot.message_count == message_count
-
     await monitor.stop()
     await connection.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# No secret material in logs/errors.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_secret_key_material_in_logs_or_errors(
+    fake_bleak: type[_FakeBleakClient],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    connection = _connection()
+
+    await connection.connect()
+    await connection.request_tcx_parameter(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+    await connection.disconnect()
+
+    key_hex = KEY_RAW.hex()
+    for record in caplog.records:
+        message = record.getMessage()
+        assert key_hex not in message
+        # BikeEncryptionKey's own __repr__/__str__ redact the key; if it is
+        # ever interpolated into a log message it must stay redacted.
+        if "BikeEncryptionKey" in message:
+            assert "<redacted>" in message
+
+    # Wrong-key failures must not leak either key's bytes in the exception.
+    bad_connection = SpecializedConnection(
+        "AA:BB:CC:DD:EE:FF",
+        bike_info=_complete_bike_info(),
+        key=BikeEncryptionKey(raw=WRONG_KEY_RAW),
+    )
+    with pytest.raises(Exception) as excinfo:
+        await bad_connection.connect()
+    assert KEY_RAW.hex() not in str(excinfo.value)
+    assert WRONG_KEY_RAW.hex() not in str(excinfo.value)

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -1,0 +1,514 @@
+"""
+Unit tests for the profile-aware TCX parsing/polling primitives in
+``coordinator_helpers``.
+
+Covers replacing the legacy "wire id == BikeParameter enum value" assumption
+with ``ProtocolRevision``-aware wire-id resolution (:mod:`specialized_turbo
+.wire_profiles`) and reverse-mapping (:func:`specialized_turbo.identification
+.parse_wire_message`), plus the revision-aware TCX polling helper and the
+now-simplified (no false key derivation) ``identify_tcx`` legacy shim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+from specialized_turbo.coordinator_helpers import (
+    TCX_POLL_PARAMS,
+    identify_tcx,
+    parse_tcx_notification,
+    parse_tcx_wire_payload,
+    poll_tcu1,
+    poll_tcx,
+)
+from specialized_turbo.models import TelemetrySnapshot
+from specialized_turbo.parameters import BikeParameter, encode_parameter_id
+from specialized_turbo.protocol import (
+    BatteryChannel,
+    BLEProfile,
+    BLEServiceID,
+    ParsedMessage,
+    Sender,
+    build_request,
+    get_service_characteristics,
+)
+from specialized_turbo.session import TCXSession
+from specialized_turbo.transport import (
+    NotificationCallback,
+    TCXNotificationTransport,
+    TCXTransportDisconnectedError,
+)
+from specialized_turbo.wire_profiles import ProtocolRevision, TCXGeneration, wire_id_for
+
+KEY_RAW = b"\x11" * 16
+IV = b"\x22" * 16
+
+# BATTERY1_STATE_OF_CHARGE (BikeParameter 26) is wire id 0x0500 for every
+# TCX generation -- *not* 0x001a, which is what the legacy enum-ID
+# assumption would (wrongly) use.
+SOC_WIRE_ID = 0x0500
+
+GENERATION = TCXGeneration.TCX2
+REVISION = 0x12  # known TCX2 revision; SYSTEM_MOTOR_TYPE etc. vary by revision
+
+
+def _revision(
+    generation: TCXGeneration = GENERATION, revision: int = REVISION
+) -> ProtocolRevision:
+    return ProtocolRevision(generation=generation, revision=revision)
+
+
+# ---------------------------------------------------------------------------
+# parse_tcx_wire_payload / parse_tcx_notification (requirement 1)
+# ---------------------------------------------------------------------------
+
+
+class TestParseTcxWirePayload:
+    def test_soc_notification_maps_to_battery_field(self) -> None:
+        """0x0500 (the real wire id) resolves to the battery SoC field."""
+        payload = encode_parameter_id(SOC_WIRE_ID) + bytes([49])
+
+        msg = parse_tcx_wire_payload(payload, _revision())
+
+        assert msg.field_name == "battery_charge_percent"
+        assert msg.converted_value == 49
+        assert msg.raw_value == 49
+        assert msg.nak_reason is None
+
+    def test_legacy_enum_id_would_have_missed_this_field(self) -> None:
+        """Sanity check: the wire id really isn't the BikeParameter enum value."""
+        assert int(BikeParameter.BATTERY1_STATE_OF_CHARGE) == 26
+        assert SOC_WIRE_ID != int(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+
+    @pytest.mark.parametrize(
+        ("generation", "revision"),
+        [
+            (TCXGeneration.TCX2, 0x12),
+            (TCXGeneration.TCX2, 0x1D),  # 29
+            (TCXGeneration.TCX3, 0x06),
+            (TCXGeneration.TCX4, 0x01),
+        ],
+    )
+    def test_resolves_across_generations_and_revisions(
+        self, generation: TCXGeneration, revision: int
+    ) -> None:
+        """SoC has one generation-wide wire id; range/consumption vary by revision."""
+        rev = ProtocolRevision(generation=generation, revision=revision)
+
+        soc_payload = encode_parameter_id(SOC_WIRE_ID) + bytes([61])
+        soc_msg = parse_tcx_wire_payload(soc_payload, rev)
+        assert soc_msg.field_name == "battery_charge_percent"
+        assert soc_msg.converted_value == 61
+
+        range_wire = wire_id_for(BikeParameter.SYSTEM_RANGE_LONG, generation, revision)
+        range_payload = encode_parameter_id(range_wire) + bytes([100, 0])
+        range_msg = parse_tcx_wire_payload(range_payload, rev)
+        assert range_msg.field_name == "range_long"
+        assert range_msg.converted_value == pytest.approx(10.0)
+
+    def test_nak_is_flagged_not_parsed_as_data(self) -> None:
+        payload = b"\xf8\xff" + encode_parameter_id(SOC_WIRE_ID) + bytes([0x05])
+
+        msg = parse_tcx_wire_payload(payload, _revision())
+
+        assert msg.nak_reason == 0x05
+        assert msg.field_name is None
+        assert msg.converted_value is None
+        assert msg.raw_value == SOC_WIRE_ID
+
+    def test_unknown_wire_id_surfaces_raw_bytes_without_a_name(self) -> None:
+        unknown_wire_id = 0xFEED
+        payload = encode_parameter_id(unknown_wire_id) + bytes([1, 2])
+
+        msg = parse_tcx_wire_payload(payload, _revision())
+
+        assert msg.field_name is None
+        assert msg.nak_reason is None
+        # Little-endian [1, 2] -> 0x0201
+        assert msg.raw_value == 0x0201
+        assert msg.converted_value == 0x0201
+
+    def test_zero_length_data_yields_field_name_with_no_value(self) -> None:
+        payload = encode_parameter_id(SOC_WIRE_ID)
+
+        msg = parse_tcx_wire_payload(payload, _revision())
+
+        assert msg.field_name == "battery_charge_percent"
+        assert msg.converted_value is None
+
+    def test_encrypted_session_data_round_trips(self) -> None:
+        """parse_tcx_notification unpacks (CRC-strip + decrypt) then parses."""
+        session = TCXSession(key=KEY_RAW, iv=IV)
+        payload = encode_parameter_id(SOC_WIRE_ID) + bytes([77])
+        packet = session.pack(payload)
+
+        # The 2-byte wire id header stays clear; the body is encrypted.
+        assert packet[:2] == encode_parameter_id(SOC_WIRE_ID)
+        assert packet[2:4] != bytes([77]) + b"\x00"
+
+        msg = parse_tcx_notification(session, packet, _revision())
+
+        assert msg.field_name == "battery_charge_percent"
+        assert msg.converted_value == 77
+
+    def test_encrypted_nak_stays_clear_and_is_flagged(self) -> None:
+        session = TCXSession(key=KEY_RAW, iv=IV)
+        nak = b"\xf8\xff" + encode_parameter_id(SOC_WIRE_ID) + bytes([0x07])
+        packet = session.pack(nak)
+
+        msg = parse_tcx_notification(session, packet, _revision())
+
+        assert msg.nak_reason == 0x07
+        assert msg.field_name is None
+
+    def test_payload_shorter_than_two_bytes_raises(self) -> None:
+        """A malformed/short response (e.g. a stray bare-byte NAK) can't be
+        parsed as a wire-id header; callers (poll_tcx) must contain this."""
+        with pytest.raises(ValueError, match="too short"):
+            parse_tcx_wire_payload(b"\x05", _revision())
+
+
+# ---------------------------------------------------------------------------
+# poll_tcx (requirement 2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCharacteristic:
+    uuid: str
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.callbacks: dict[str, NotificationCallback] = {}
+        self.writes: list[tuple[str, bytes]] = []
+        self.on_write: Callable[[str, bytes], None] | None = None
+
+    async def start_notify(
+        self, characteristic: str, callback: NotificationCallback
+    ) -> None:
+        self.callbacks[characteristic] = callback
+
+    async def stop_notify(self, characteristic: str) -> None:
+        self.callbacks.pop(characteristic, None)
+
+    async def write_gatt_char(
+        self, characteristic: str, data: bytes, response: bool | None = None
+    ) -> None:
+        packet = bytes(data)
+        self.writes.append((characteristic, packet))
+        if self.on_write is not None:
+            self.on_write(characteristic, packet)
+
+    def notify(self, service_id: BLEServiceID, data: bytes) -> None:
+        uuid = get_service_characteristics(BLEProfile.TCX, service_id).notify
+        callback = self.callbacks[uuid]
+        characteristic = cast(BleakGATTCharacteristic, _FakeCharacteristic(uuid))
+        callback(characteristic, bytearray(data))
+
+
+class _FakeBike:
+    """Answers wire-id requests with unencrypted, CRC-framed responses."""
+
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+        self._session = TCXSession()
+        self._payloads: dict[int, bytes] = {}
+        self._naks: dict[int, int] = {}
+        self.requests: list[int] = []
+        client.on_write = self._on_write
+
+    def set_value(self, wire_id: int, body: bytes) -> None:
+        self._payloads[wire_id] = encode_parameter_id(wire_id) + bytes(body)
+
+    def set_nak(self, wire_id: int, reason: int) -> None:
+        self._naks[wire_id] = reason
+
+    def _on_write(self, _characteristic: str, packet: bytes) -> None:
+        wire_id = int.from_bytes(packet[:2], "big")
+        self.requests.append(wire_id)
+        if wire_id in self._naks:
+            frame = self._session.pack(
+                b"\xf8\xff"
+                + encode_parameter_id(wire_id)
+                + bytes([self._naks[wire_id]])
+            )
+        elif wire_id in self._payloads:
+            frame = self._session.pack(self._payloads[wire_id])
+        else:
+            return  # no response configured -> request stays pending
+        self._client.notify(BLEServiceID.REQUEST, frame)
+
+
+def _transport(client: _FakeClient) -> TCXNotificationTransport:
+    return TCXNotificationTransport(cast(BleakClient, client), request_timeout=1.0)
+
+
+def _wire_id(param: BikeParameter, rev: ProtocolRevision) -> int:
+    return wire_id_for(param, rev.generation, rev.revision)
+
+
+class TestPollTcx:
+    async def test_polls_wire_mapped_ids_and_updates_snapshot(self) -> None:
+        client = _FakeClient()
+        bike = _FakeBike(client)
+        rev = _revision()
+        for param in TCX_POLL_PARAMS:
+            bike.set_value(_wire_id(param, rev), bytes([5]))
+        transport = _transport(client)
+        snapshot = TelemetrySnapshot()
+
+        updated = await poll_tcx(transport, snapshot, rev)
+
+        assert updated is True
+        # Every request used the real wire id, not the BikeParameter enum id.
+        assert bike.requests == [_wire_id(p, rev) for p in TCX_POLL_PARAMS]
+        assert SOC_WIRE_ID in bike.requests
+        assert int(BikeParameter.BATTERY1_STATE_OF_CHARGE) not in bike.requests
+        assert snapshot.battery.charge_pct == 5
+        assert snapshot.message_count > 0
+
+    async def test_nak_is_skipped_without_touching_snapshot(self) -> None:
+        client = _FakeClient()
+        bike = _FakeBike(client)
+        rev = _revision()
+        soc_wire = _wire_id(BikeParameter.BATTERY1_STATE_OF_CHARGE, rev)
+        bike.set_nak(soc_wire, 0x05)
+        for param in TCX_POLL_PARAMS:
+            wire = _wire_id(param, rev)
+            if wire != soc_wire:
+                bike.set_value(wire, bytes([9]))
+        transport = _transport(client)
+        snapshot = TelemetrySnapshot()
+
+        updated = await poll_tcx(transport, snapshot, rev)
+
+        assert updated is True  # other fields still updated
+        assert snapshot.battery.charge_pct is None
+        assert snapshot.motor.motor_power_w == 9
+
+    async def test_unmapped_parameter_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import specialized_turbo.coordinator_helpers as ch
+
+        # BATTERY1_FAULT_LOG_ENTRIES has no wire id in any generation/revision.
+        monkeypatch.setattr(
+            ch, "TCX_POLL_PARAMS", (BikeParameter.BATTERY1_FAULT_LOG_ENTRIES,)
+        )
+        client = _FakeClient()
+        transport = _transport(client)
+        snapshot = TelemetrySnapshot()
+
+        updated = await ch.poll_tcx(transport, snapshot, _revision())
+
+        assert updated is False
+        assert client.writes == []  # never even attempted a request
+
+    async def test_malformed_payload_is_contained_to_current_parameter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A parse failure (e.g. an unexpectedly short/malformed response)
+        for one parameter must not abort polling the rest."""
+        import specialized_turbo.coordinator_helpers as ch
+
+        client = _FakeClient()
+        bike = _FakeBike(client)
+        rev = _revision()
+        for param in TCX_POLL_PARAMS:
+            bike.set_value(_wire_id(param, rev), bytes([5]))
+        transport = _transport(client)
+        snapshot = TelemetrySnapshot()
+
+        soc_wire = _wire_id(BikeParameter.BATTERY1_STATE_OF_CHARGE, rev)
+        real_parse = ch.parse_tcx_wire_payload
+
+        def flaky_parse(payload: bytes, revision: ProtocolRevision):
+            if int.from_bytes(payload[:2], "big") == soc_wire:
+                raise ValueError("Payload too short (1 bytes), need at least 2")
+            return real_parse(payload, revision)
+
+        monkeypatch.setattr(ch, "parse_tcx_wire_payload", flaky_parse)
+
+        updated = await ch.poll_tcx(transport, snapshot, rev)
+
+        assert updated is True
+        assert snapshot.battery.charge_pct is None  # SOC parse failed, skipped
+        assert snapshot.motor.motor_power_w == 5  # other params still updated
+
+    async def test_snapshot_update_failure_is_contained_to_current_parameter(
+        self,
+    ) -> None:
+        """update_from_message raising for one message must not abort the rest."""
+        client = _FakeClient()
+        bike = _FakeBike(client)
+        rev = _revision()
+        for param in TCX_POLL_PARAMS:
+            bike.set_value(_wire_id(param, rev), bytes([5]))
+        transport = _transport(client)
+
+        class _FlakySnapshot(TelemetrySnapshot):
+            def update_from_message(self, msg: ParsedMessage) -> None:
+                if msg.field_name == "battery_charge_percent":
+                    raise RuntimeError("boom")
+                super().update_from_message(msg)
+
+        snapshot = _FlakySnapshot()
+
+        updated = await poll_tcx(transport, snapshot, rev)
+
+        assert updated is True
+        assert snapshot.battery.charge_pct is None
+        assert snapshot.motor.motor_power_w == 5
+
+    async def test_disconnect_propagates(self) -> None:
+        client = _FakeClient()
+        transport = _transport(client)
+        snapshot = TelemetrySnapshot()
+        transport.mark_disconnected()
+
+        with pytest.raises(TCXTransportDisconnectedError):
+            await poll_tcx(transport, snapshot, _revision())
+
+
+# ---------------------------------------------------------------------------
+# poll_tcu1 (requirement: TCU1 unchanged)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTcu1Client:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+        self.responses: dict[bytes, bytes] = {}
+
+    async def write_gatt_char(self, _characteristic: str, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    async def read_gatt_char(self, _characteristic: str) -> bytes:
+        return self.responses[self.writes[-1]]
+
+
+class TestPollTcu1:
+    async def test_polls_sender_channel_pairs_unchanged(self) -> None:
+        client = _FakeTcu1Client()
+        request = build_request(Sender.BATTERY, BatteryChannel.CHARGE_PERCENT)
+        client.responses[request] = bytes(
+            [Sender.BATTERY, BatteryChannel.CHARGE_PERCENT, 42]
+        )
+        snapshot = TelemetrySnapshot()
+
+        updated = await poll_tcu1(
+            cast(BleakClient, client), "write-char", "read-char", snapshot
+        )
+
+        assert updated is True
+        assert snapshot.battery.charge_pct == 42
+
+
+# ---------------------------------------------------------------------------
+# identify_tcx legacy shim (requirement 6: no more false key derivation)
+# ---------------------------------------------------------------------------
+
+
+class _IdentClient:
+    def __init__(self) -> None:
+        self.callbacks: dict[str, NotificationCallback] = {}
+        self.on_write: Callable[[str, bytes], None] | None = None
+
+    async def start_notify(
+        self, characteristic: str, callback: NotificationCallback
+    ) -> None:
+        self.callbacks[characteristic] = callback
+
+    async def stop_notify(self, characteristic: str) -> None:
+        self.callbacks.pop(characteristic, None)
+
+    async def write_gatt_char(
+        self, characteristic: str, data: bytes, response: bool | None = None
+    ) -> None:
+        packet = bytes(data)
+        if self.on_write is not None:
+            self.on_write(characteristic, packet)
+
+    def notify(self, service_id: BLEServiceID, data: bytes) -> None:
+        uuid = get_service_characteristics(BLEProfile.TCX, service_id).notify
+        callback = self.callbacks[uuid]
+        characteristic = cast(BleakGATTCharacteristic, _FakeCharacteristic(uuid))
+        callback(characteristic, bytearray(data))
+
+
+class TestIdentifyTcxLegacyShim:
+    async def test_always_returns_unencrypted_session_even_with_long_firmware_body(
+        self,
+    ) -> None:
+        """Even a >=20 byte BATTERY1_FIRMWARE response is never treated as a key."""
+        client = _IdentClient()
+        session = TCXSession()
+
+        def respond(_characteristic: str, packet: bytes) -> None:
+            wire_id = int.from_bytes(packet[:2], "big")
+            if wire_id == int(BikeParameter.BATTERY1_FIRMWARE):
+                # Looks superficially "key-like" (>=20 bytes after the
+                # 2-byte header) but must never be used as key material.
+                body = b"A" * 32
+            else:
+                body = bytes([1, 2, 3])
+            frame = session.pack(encode_parameter_id(wire_id) + body)
+            client.notify(BLEServiceID.REQUEST, frame)
+
+        client.on_write = respond
+        transport = TCXNotificationTransport(
+            cast(BleakClient, client), request_timeout=1.0
+        )
+
+        result = await identify_tcx(transport)
+
+        assert isinstance(result, TCXSession)
+        assert result.encrypted is False
+
+    async def test_naks_are_logged_but_do_not_abort_the_sequence(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _IdentClient()
+        session = TCXSession()
+
+        def respond(_characteristic: str, packet: bytes) -> None:
+            wire_id = int.from_bytes(packet[:2], "big")
+            if wire_id == int(BikeParameter.SYSTEM_STATE):
+                frame = session.pack(
+                    b"\xf8\xff" + encode_parameter_id(wire_id) + bytes([0x02])
+                )
+            else:
+                frame = session.pack(encode_parameter_id(wire_id) + bytes([1]))
+            client.notify(BLEServiceID.REQUEST, frame)
+
+        client.on_write = respond
+        transport = TCXNotificationTransport(
+            cast(BleakClient, client), request_timeout=1.0
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await identify_tcx(transport)
+
+        assert result.encrypted is False
+        assert any("rejected by bike" in r.message for r in caplog.records)
+
+    async def test_disconnect_propagates(self) -> None:
+        client = _IdentClient()
+        transport = TCXNotificationTransport(
+            cast(BleakClient, client), request_timeout=60
+        )
+        task = asyncio.create_task(identify_tcx(transport))
+        await asyncio.sleep(0)
+
+        transport.mark_disconnected()
+
+        with pytest.raises(TCXTransportDisconnectedError):
+            await task

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -275,6 +275,53 @@ class TestFullHandshake:
         assert ident.session.encrypted
         assert transport.session is ident.session
 
+    async def test_public_identify_installs_revision_for_immediate_transport_use(self):
+        """identify() installs the revision so the transport is usable at once.
+
+        An external client (e.g. Home Assistant) that drives the transport
+        directly -- without a ``SpecializedConnection`` -- must be able to
+        call request_bike_parameter/write_bike_parameter/set_realtime_enabled
+        immediately after identify() returns, i.e. the negotiated
+        ProtocolRevision is installed on the transport alongside the session.
+        """
+        client = _FakeClient()
+        bike = _healthy_bike(client)
+        bike.set_body(_wire(BikeParameter.BATTERY1_STATE_OF_CHARGE), bytes([49]))
+        transport = _transport(client)
+
+        result = await identify(
+            transport, _complete_bike_info(), BikeEncryptionKey(raw=KEY_RAW)
+        )
+
+        # Revision installed on the transport as part of identification.
+        assert transport.protocol_revision == result.protocol_revision
+        assert transport.protocol_revision == ProtocolRevision(GENERATION, REVISION)
+
+        data_write = get_service_characteristics(
+            BLEProfile.TCX, BLEServiceID.DATA
+        ).write
+
+        # A read resolves the BikeParameter to its real wire id (0x0500).
+        raw = await transport.request_bike_parameter(
+            BikeParameter.BATTERY1_STATE_OF_CHARGE
+        )
+        assert bike.requests[-1] == 0x0500
+        assert parse_wire_message(raw, GENERATION, REVISION).value == 49
+
+        # A write resolves MOTOR_ACTIVE_TRAVEL_MODE to wire 0x07fa on service 3.
+        await transport.write_bike_parameter(
+            BikeParameter.MOTOR_ACTIVE_TRAVEL_MODE, bytes([2])
+        )
+        write_char, write_packet = client.writes[-1]
+        assert write_char == data_write
+        assert transport.session.unpack(write_packet)[:3] == bytes([0x07, 0xFA, 0x02])
+
+        # set_realtime_enabled resolves SYSTEM_REAL_TIME_DATA_ENB to 0x080f.
+        await transport.set_realtime_enabled(True)
+        enable_char, enable_packet = client.writes[-1]
+        assert enable_char == data_write
+        assert transport.session.unpack(enable_packet)[:3] == bytes.fromhex("080f01")
+
 
 # ---------------------------------------------------------------------------
 # IV installation + revision selection (requirement 6)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -25,13 +25,20 @@ from typing import cast
 import pytest
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
+import specialized_turbo.telemetry as telemetry_module
+from specialized_turbo.bike_info import BikeInfo
 from specialized_turbo.connection import SpecializedConnection
 from specialized_turbo.coordinator_helpers import TCX_POLL_PARAMS
 from specialized_turbo.identification import WireMessage
+from specialized_turbo.keystore.models import BikeEncryptionKey
 from specialized_turbo.parameters import BikeParameter, encode_parameter_id
-from specialized_turbo.protocol import BatteryChannel, ParsedMessage, Sender
+from specialized_turbo.protocol import BatteryChannel, BLEProfile, ParsedMessage, Sender
 from specialized_turbo.session import ProtocolSession, TCU1Session, TCXSession
-from specialized_turbo.telemetry import RevisionAwareConnection, TelemetryMonitor
+from specialized_turbo.telemetry import (
+    RevisionAwareConnection,
+    TelemetryMonitor,
+    run_telemetry_session,
+)
 from specialized_turbo.transport import NotificationCallback, TCXRequestTimeoutError
 from specialized_turbo.wire_profiles import (
     ProtocolRevision,
@@ -340,3 +347,100 @@ class TestTcu1Unchanged:
 
         assert monitor.snapshot.battery.charge_pct == 55
         await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# run_telemetry_session forwards generation / bike_info / key to the connection
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConnection:
+    """Fake SpecializedConnection that records its constructor kwargs."""
+
+    captured: dict[str, object] = {}
+
+    def __init__(
+        self,
+        address: str,
+        *,
+        pin: str | None = None,
+        generation: BLEProfile = BLEProfile.TCX,
+        bike_info: BikeInfo | None = None,
+        key: BikeEncryptionKey | None = None,
+    ) -> None:
+        type(self).captured = {
+            "address": address,
+            "pin": pin,
+            "generation": generation,
+            "bike_info": bike_info,
+            "key": key,
+        }
+        self._session: ProtocolSession = (
+            TCU1Session() if generation == BLEProfile.TCU1 else TCXSession()
+        )
+
+    @property
+    def session(self) -> ProtocolSession:
+        return self._session
+
+    async def __aenter__(self) -> _RecordingConnection:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def subscribe_notifications(self, callback: NotificationCallback) -> None:
+        return None
+
+    async def unsubscribe_notifications(self) -> None:
+        return None
+
+
+class TestRunTelemetrySessionForwarding:
+    async def test_forwards_tcu1_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            telemetry_module, "SpecializedConnection", _RecordingConnection
+        )
+
+        await run_telemetry_session(
+            "AA:BB:CC:DD:EE:FF",
+            pin="946166",
+            generation=BLEProfile.TCU1,
+            duration=0.001,
+            output_callback=lambda _s: None,
+        )
+
+        assert _RecordingConnection.captured == {
+            "address": "AA:BB:CC:DD:EE:FF",
+            "pin": "946166",
+            "generation": BLEProfile.TCU1,
+            "bike_info": None,
+            "key": None,
+        }
+
+    async def test_forwards_tcx_bike_info_and_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            telemetry_module, "SpecializedConnection", _RecordingConnection
+        )
+        info = BikeInfo(
+            name="SPECIALIZED", bike_name="LEVO2", is_bike=True, complete=True
+        )
+        key = BikeEncryptionKey(raw=KEY_RAW)
+
+        await run_telemetry_session(
+            "AA:BB:CC:DD:EE:FF",
+            pin="946166",
+            generation=BLEProfile.TCX,
+            bike_info=info,
+            key=key,
+            duration=0.001,
+            output_callback=lambda _s: None,
+        )
+
+        captured = _RecordingConnection.captured
+        assert captured["generation"] == BLEProfile.TCX
+        assert captured["bike_info"] is info
+        assert captured["key"] is key
+        assert captured["pin"] == "946166"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,287 @@
+"""
+Unit tests for ``TelemetryMonitor``'s profile-aware TCX notification
+handling.
+
+A duck-typed fake stands in for ``SpecializedConnection`` (which this
+module deliberately doesn't touch -- its identification/revision-negotiation
+story is landing in parallel).  Two fake connection variants exercise both
+sides of ``TelemetryMonitor._active_revision``'s narrow lookup:
+
+- one with no ``active_revision`` attribute at all (today's
+  ``SpecializedConnection``) -- notifications fall back to the legacy,
+  non-profile-aware parse.
+- one that implements :class:`~specialized_turbo.telemetry
+  .RevisionAwareConnection` -- notifications are parsed profile-aware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import cast
+
+import pytest
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+from specialized_turbo.connection import SpecializedConnection
+from specialized_turbo.coordinator_helpers import TCX_POLL_PARAMS
+from specialized_turbo.parameters import BikeParameter, encode_parameter_id
+from specialized_turbo.protocol import BatteryChannel, ParsedMessage, Sender
+from specialized_turbo.session import ProtocolSession, TCU1Session, TCXSession
+from specialized_turbo.telemetry import RevisionAwareConnection, TelemetryMonitor
+from specialized_turbo.transport import NotificationCallback, TCXRequestTimeoutError
+from specialized_turbo.wire_profiles import ProtocolRevision, TCXGeneration
+
+KEY_RAW = b"\x11" * 16
+IV = b"\x22" * 16
+
+SOC_WIRE_ID = 0x0500  # real wire id for BATTERY1_STATE_OF_CHARGE (26)
+GENERATION = TCXGeneration.TCX2
+REVISION = 0x12
+
+
+@dataclass
+class _FakeCharacteristic:
+    uuid: str
+
+
+_CHARACTERISTIC = cast(BleakGATTCharacteristic, _FakeCharacteristic("fake"))
+
+
+@dataclass
+class _FakeConnection:
+    """Duck-typed stand-in exposing only what ``TelemetryMonitor`` needs."""
+
+    session: ProtocolSession
+    requested_params: list[int] = field(default_factory=list)
+    timeout_after: int | None = None
+    _callback: NotificationCallback | None = field(default=None, init=False)
+
+    async def subscribe_notifications(self, callback: NotificationCallback) -> None:
+        self._callback = callback
+
+    async def unsubscribe_notifications(self) -> None:
+        self._callback = None
+
+    async def request_tcx_value(self, param_id: int) -> ParsedMessage:
+        self.requested_params.append(param_id)
+        if self.timeout_after is not None and len(self.requested_params) > (
+            self.timeout_after
+        ):
+            raise TCXRequestTimeoutError(param_id, 0.001)
+        return ParsedMessage(
+            sender=0,
+            channel=0,
+            raw_value=0,
+            converted_value=None,
+            field_name=None,
+            unit="",
+        )
+
+    def notify(self, data: bytes) -> None:
+        assert self._callback is not None
+        self._callback(_CHARACTERISTIC, bytearray(data))
+
+
+@dataclass
+class _FakeRevisionAwareConnection(_FakeConnection):
+    """Same as ``_FakeConnection`` but implements ``active_revision``."""
+
+    revision: ProtocolRevision | None = None
+
+    @property
+    def active_revision(self) -> ProtocolRevision | None:
+        return self.revision
+
+
+def _revision() -> ProtocolRevision:
+    return ProtocolRevision(generation=GENERATION, revision=REVISION)
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback when no revision is available (requirement 3)
+# ---------------------------------------------------------------------------
+
+
+class TestFallsBackWithoutRevision:
+    async def test_plain_connection_has_no_active_revision(self) -> None:
+        conn = _FakeConnection(session=TCXSession())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        assert monitor._active_revision() is None
+
+    async def test_legacy_parse_used_when_revision_unknown(self) -> None:
+        """Without a revision, notifications parse via the legacy enum-ID path."""
+        conn = _FakeConnection(session=TCXSession())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        # Legacy parse_tcx_message treats the wire header as the
+        # BikeParameter enum value directly: 26 == BATTERY1_STATE_OF_CHARGE.
+        legacy_wire = int(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+        packet = TCXSession().pack(encode_parameter_id(legacy_wire) + bytes([37]))
+        conn.notify(packet)
+
+        assert monitor.snapshot.battery.charge_pct == 37
+        await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Profile-aware parse when a revision is available (requirements 1 & 3)
+# ---------------------------------------------------------------------------
+
+
+class TestProfileAwareWithRevision:
+    async def test_uses_wire_id_for_active_revision(self) -> None:
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        assert isinstance(conn, RevisionAwareConnection)
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        # The real wire id (0x0500), not the BikeParameter enum id (26).
+        packet = TCXSession().pack(encode_parameter_id(SOC_WIRE_ID) + bytes([61]))
+        conn.notify(packet)
+
+        assert monitor.snapshot.battery.charge_pct == 61
+        await monitor.stop()
+
+    async def test_legacy_wire_id_no_longer_resolves_once_profile_aware(self) -> None:
+        """0x001a isn't a real TCX2 wire id; profile-aware parsing leaves it unknown."""
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        legacy_wire = int(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+        packet = TCXSession().pack(encode_parameter_id(legacy_wire) + bytes([37]))
+        conn.notify(packet)
+
+        assert monitor.snapshot.battery.charge_pct is None
+        await monitor.stop()
+
+    async def test_encrypted_session_notification_decrypts_and_parses(self) -> None:
+        session = TCXSession(key=KEY_RAW, iv=IV)
+        conn = _FakeRevisionAwareConnection(session=session, revision=_revision())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        packet = session.pack(encode_parameter_id(SOC_WIRE_ID) + bytes([88]))
+        conn.notify(packet)
+
+        assert monitor.snapshot.battery.charge_pct == 88
+        await monitor.stop()
+
+    async def test_nak_increments_count_without_updating_snapshot(self) -> None:
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        nak = b"\xf8\xff" + encode_parameter_id(SOC_WIRE_ID) + bytes([0x05])
+        conn.notify(TCXSession().pack(nak))
+
+        assert monitor.nak_count == 1
+        assert monitor.snapshot.battery.charge_pct is None
+        await monitor.stop()
+
+    async def test_realtime_bundle_still_suppressed_regardless_of_revision(
+        self,
+    ) -> None:
+        """f8f4 bundles are explicitly suppressed, not misparsed (requirement 4)."""
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        before = monitor.snapshot.message_count
+        conn.notify(TCXSession().pack(b"\xf8\xf4" + bytes(16)))
+
+        assert monitor.snapshot.message_count == before
+        assert monitor.nak_count == 0
+        await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Injectable revision accessor (requirement 3: alternative to the protocol)
+# ---------------------------------------------------------------------------
+
+
+class TestInjectableRevisionAccessor:
+    async def test_accessor_takes_priority_over_connection_attribute(self) -> None:
+        conn = _FakeConnection(session=TCXSession())  # no active_revision at all
+        accessor_calls: list[int] = []
+
+        def accessor() -> ProtocolRevision | None:
+            accessor_calls.append(1)
+            return _revision()
+
+        monitor = TelemetryMonitor(
+            cast(SpecializedConnection, conn), revision_accessor=accessor
+        )
+
+        assert monitor._active_revision() == _revision()
+        assert accessor_calls == [1]
+
+    async def test_accessor_returning_none_falls_back_to_legacy_parse(self) -> None:
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        monitor = TelemetryMonitor(
+            cast(SpecializedConnection, conn), revision_accessor=lambda: None
+        )
+        await monitor.start()
+
+        legacy_wire = int(BikeParameter.BATTERY1_STATE_OF_CHARGE)
+        packet = TCXSession().pack(encode_parameter_id(legacy_wire) + bytes([12]))
+        conn.notify(packet)
+
+        assert monitor.snapshot.battery.charge_pct == 12
+        await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# Initial snapshot priming (requirement 5)
+# ---------------------------------------------------------------------------
+
+
+class TestPrimeTcxSnapshot:
+    async def test_primes_every_poll_param_through_legacy_request(self) -> None:
+        conn = _FakeConnection(session=TCXSession())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        await monitor.start()
+
+        assert conn.requested_params == [int(p) for p in TCX_POLL_PARAMS]
+        await monitor.stop()
+
+    async def test_priming_stops_on_first_timeout(self) -> None:
+        conn = _FakeConnection(session=TCXSession(), timeout_after=2)
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        await monitor.start()
+
+        assert len(conn.requested_params) == 3  # 2 ok + the one that times out
+        await monitor.stop()
+
+    async def test_reports_priming_is_still_legacy_when_revision_known(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        with caplog.at_level("INFO"):
+            await monitor.start()
+
+        assert any("priming is still legacy" in r.message for r in caplog.records)
+        await monitor.stop()
+
+
+# ---------------------------------------------------------------------------
+# TCU1 unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestTcu1Unchanged:
+    async def test_tcu1_notifications_use_the_legacy_sender_channel_parse(self) -> None:
+        conn = _FakeConnection(session=TCU1Session())
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+        await monitor.start()
+
+        conn.notify(bytes([Sender.BATTERY, BatteryChannel.CHARGE_PERCENT, 55]))
+
+        assert monitor.snapshot.battery.charge_pct == 55
+        await monitor.stop()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,17 +1,20 @@
 """
 Unit tests for ``TelemetryMonitor``'s profile-aware TCX notification
-handling.
+handling and priming.
 
-A duck-typed fake stands in for ``SpecializedConnection`` (which this
-module deliberately doesn't touch -- its identification/revision-negotiation
-story is landing in parallel).  Two fake connection variants exercise both
-sides of ``TelemetryMonitor._active_revision``'s narrow lookup:
+A duck-typed fake stands in for ``SpecializedConnection``. Two fake
+connection variants exercise both sides of
+``TelemetryMonitor._active_revision``'s narrow, type-validated lookup:
 
-- one with no ``active_revision`` attribute at all (today's
-  ``SpecializedConnection``) -- notifications fall back to the legacy,
-  non-profile-aware parse.
+- one with no ``active_revision`` attribute at all -- notifications fall
+  back to the legacy, non-profile-aware parse and priming is skipped.
 - one that implements :class:`~specialized_turbo.telemetry
-  .RevisionAwareConnection` -- notifications are parsed profile-aware.
+  .RevisionAwareConnection` (as the real ``SpecializedConnection`` now does)
+  -- notifications are parsed profile-aware and priming addresses each poll
+  parameter through the revision-aware ``request_tcx_parameter``.
+
+The fake's ``request_tcx_value`` deliberately raises: priming (and every
+other live path) must never fall back to the deprecated raw enum-id call.
 """
 
 from __future__ import annotations
@@ -24,12 +27,17 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from specialized_turbo.connection import SpecializedConnection
 from specialized_turbo.coordinator_helpers import TCX_POLL_PARAMS
+from specialized_turbo.identification import WireMessage
 from specialized_turbo.parameters import BikeParameter, encode_parameter_id
 from specialized_turbo.protocol import BatteryChannel, ParsedMessage, Sender
 from specialized_turbo.session import ProtocolSession, TCU1Session, TCXSession
 from specialized_turbo.telemetry import RevisionAwareConnection, TelemetryMonitor
 from specialized_turbo.transport import NotificationCallback, TCXRequestTimeoutError
-from specialized_turbo.wire_profiles import ProtocolRevision, TCXGeneration
+from specialized_turbo.wire_profiles import (
+    ProtocolRevision,
+    TCXGeneration,
+    UnmappedParameterError,
+)
 
 KEY_RAW = b"\x11" * 16
 IV = b"\x22" * 16
@@ -52,8 +60,9 @@ class _FakeConnection:
     """Duck-typed stand-in exposing only what ``TelemetryMonitor`` needs."""
 
     session: ProtocolSession
-    requested_params: list[int] = field(default_factory=list)
+    requested_params: list[BikeParameter] = field(default_factory=list)
     timeout_after: int | None = None
+    unmapped: set[BikeParameter] = field(default_factory=set)
     _callback: NotificationCallback | None = field(default=None, init=False)
 
     async def subscribe_notifications(self, callback: NotificationCallback) -> None:
@@ -62,19 +71,23 @@ class _FakeConnection:
     async def unsubscribe_notifications(self) -> None:
         self._callback = None
 
-    async def request_tcx_value(self, param_id: int) -> ParsedMessage:
-        self.requested_params.append(param_id)
+    async def request_tcx_parameter(
+        self, param: BikeParameter, *, timeout: float | None = None
+    ) -> WireMessage:
+        """Profile-aware read used by ``_prime_tcx_snapshot``."""
+        if param in self.unmapped:
+            raise UnmappedParameterError(param.name)
+        self.requested_params.append(param)
         if self.timeout_after is not None and len(self.requested_params) > (
             self.timeout_after
         ):
-            raise TCXRequestTimeoutError(param_id, 0.001)
-        return ParsedMessage(
-            sender=0,
-            channel=0,
-            raw_value=0,
-            converted_value=None,
-            field_name=None,
-            unit="",
+            raise TCXRequestTimeoutError(int(param), 0.001)
+        return WireMessage(wire_id=int(param), parameter=param, data=b"", value=None)
+
+    async def request_tcx_value(self, param_id: int) -> ParsedMessage:
+        """Deprecated raw path -- must never be reached from live code."""
+        raise AssertionError(
+            "TelemetryMonitor must not use the deprecated raw request_tcx_value"
         )
 
     def notify(self, data: bytes) -> None:
@@ -232,24 +245,43 @@ class TestInjectableRevisionAccessor:
         assert monitor.snapshot.battery.charge_pct == 12
         await monitor.stop()
 
+    async def test_wrong_type_is_rejected_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-ProtocolRevision value is ignored, not passed to wire lookup."""
+        conn = _FakeConnection(session=TCXSession())
+        monitor = TelemetryMonitor(
+            cast(SpecializedConnection, conn),
+            revision_accessor=lambda: cast(ProtocolRevision, "not-a-revision"),
+        )
+
+        with caplog.at_level("WARNING"):
+            assert monitor._active_revision() is None
+
+        assert any("unexpected type" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
-# Initial snapshot priming (requirement 5)
+# Initial snapshot priming (requirements 2 & 5): profile-aware, atomic switch
 # ---------------------------------------------------------------------------
 
 
 class TestPrimeTcxSnapshot:
-    async def test_primes_every_poll_param_through_legacy_request(self) -> None:
-        conn = _FakeConnection(session=TCXSession())
+    async def test_primes_every_poll_param_profile_aware(self) -> None:
+        conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
         monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
 
         await monitor.start()
 
-        assert conn.requested_params == [int(p) for p in TCX_POLL_PARAMS]
+        # Priming addresses each poll parameter by BikeParameter (resolved to
+        # a wire id inside request_tcx_parameter), never the raw enum id.
+        assert conn.requested_params == list(TCX_POLL_PARAMS)
         await monitor.stop()
 
     async def test_priming_stops_on_first_timeout(self) -> None:
-        conn = _FakeConnection(session=TCXSession(), timeout_after=2)
+        conn = _FakeRevisionAwareConnection(
+            session=TCXSession(), revision=_revision(), timeout_after=2
+        )
         monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
 
         await monitor.start()
@@ -257,7 +289,30 @@ class TestPrimeTcxSnapshot:
         assert len(conn.requested_params) == 3  # 2 ok + the one that times out
         await monitor.stop()
 
-    async def test_reports_priming_is_still_legacy_when_revision_known(
+    async def test_unmapped_parameter_is_skipped_not_fatal(self) -> None:
+        first = TCX_POLL_PARAMS[0]
+        conn = _FakeRevisionAwareConnection(
+            session=TCXSession(), revision=_revision(), unmapped={first}
+        )
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        await monitor.start()
+
+        assert first not in conn.requested_params
+        assert conn.requested_params == [p for p in TCX_POLL_PARAMS if p != first]
+        await monitor.stop()
+
+    async def test_no_priming_without_revision(self) -> None:
+        """Without a revision, priming is skipped -- never the raw enum path."""
+        conn = _FakeConnection(session=TCXSession())  # no active_revision
+        monitor = TelemetryMonitor(cast(SpecializedConnection, conn))
+
+        await monitor.start()
+
+        assert conn.requested_params == []
+        await monitor.stop()
+
+    async def test_reports_priming_is_profile_aware_when_revision_known(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         conn = _FakeRevisionAwareConnection(session=TCXSession(), revision=_revision())
@@ -266,7 +321,7 @@ class TestPrimeTcxSnapshot:
         with caplog.at_level("INFO"):
             await monitor.start()
 
-        assert any("priming is still legacy" in r.message for r in caplog.records)
+        assert any("profile-aware" in r.message for r in caplog.records)
         await monitor.stop()
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -12,6 +12,7 @@ from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from specialized_turbo.framing import pack_tcx, unpack_tcx
+from specialized_turbo.parameters import BikeParameter
 from specialized_turbo.protocol import (
     BLEProfile,
     BLEServiceID,
@@ -24,10 +25,12 @@ from specialized_turbo.transport import (
     BLETraceEvent,
     NotificationCallback,
     TCXNotificationTransport,
+    TCXProtocolNotNegotiatedError,
     TCXRequestTimeoutError,
     TCXTransportDisconnectedError,
     TraceCallback,
 )
+from specialized_turbo.wire_profiles import ProtocolRevision, TCXGeneration
 
 
 @dataclass
@@ -218,14 +221,28 @@ async def test_disconnect_fails_pending_request_immediately() -> None:
 async def test_realtime_enable_uses_service_three_write() -> None:
     client = _FakeClient()
     transport = _transport(client)
+    transport.protocol_revision = ProtocolRevision(TCXGeneration.TCX2, 0x12)
 
     await transport.set_realtime_enabled(True)
 
     service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.DATA)
     characteristic, packet, response = client.writes[-1]
     assert characteristic == service.write
-    assert unpack_tcx(packet)[:3] == bytes.fromhex("015a01")
+    # SYSTEM_REAL_TIME_DATA_ENB resolves to wire 0x080f, not its raw
+    # BikeParameter value (346 / 0x015a) -- see wire_profiles.
+    assert unpack_tcx(packet)[:3] == bytes.fromhex("080f01")
     assert response is False
+
+
+@pytest.mark.asyncio
+async def test_realtime_enable_requires_negotiated_revision() -> None:
+    client = _FakeClient()
+    transport = _transport(client)
+
+    with pytest.raises(
+        TCXProtocolNotNegotiatedError, match="SYSTEM_REAL_TIME_DATA_ENB"
+    ):
+        await transport.set_realtime_enabled(True)
 
 
 @pytest.mark.asyncio
@@ -246,6 +263,35 @@ async def test_trace_records_full_write_and_notification_payloads() -> None:
     assert [event.direction for event in events] == ["tx", "rx"]
     assert all(len(event.data) == 20 for event in events)
     assert events[0].service_id == BLEServiceID.REQUEST
+
+
+@pytest.mark.asyncio
+async def test_request_bike_parameter_resolves_soc_wire_0500() -> None:
+    client = _FakeClient()
+    transport = _transport(client)
+    transport.protocol_revision = ProtocolRevision(TCXGeneration.TCX2, 0x12)
+
+    def respond(characteristic: str, packet: bytes) -> None:
+        service = get_service_characteristics(BLEProfile.TCX, BLEServiceID.REQUEST)
+        assert characteristic == service.write
+        assert unpack_tcx(packet)[:2] == bytes.fromhex("0500")
+        client.notify(BLEServiceID.REQUEST, pack_tcx(bytes.fromhex("050031")))
+
+    client.on_write = respond
+    response = await transport.request_bike_parameter(
+        BikeParameter.BATTERY1_STATE_OF_CHARGE
+    )
+
+    assert parse_tcx_message(response).converted_value == 49
+
+
+@pytest.mark.asyncio
+async def test_request_bike_parameter_requires_negotiated_revision() -> None:
+    client = _FakeClient()
+    transport = _transport(client)
+
+    with pytest.raises(TCXProtocolNotNegotiatedError, match="BATTERY1_STATE_OF_CHARGE"):
+        await transport.request_bike_parameter(BikeParameter.BATTERY1_STATE_OF_CHARGE)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Wire mapped TCX identification, telemetry, polling, and writes through the public connection API.