### PR TITLE
Add offline TCX key-file CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,19 @@ Async, built on [bleak](https://github.com/hbldh/bleak). Includes a CLI. Protoco
 pip install specialized-turbo
 ```
 
+Every command (`scan`, `telemetry`, `read`, `write`, `capture`, `services`)
+works out of the box; there are no optional extras.
+
 ## Quick start
 
 > **TCX2+ bikes (Vado/Levo/Creo SL, etc.) require identification.** Pass the
 > parsed advertisement (`bike_info`, from `parse_bike_info`) and the bike's
-> AES key (`key`, a `BikeEncryptionKey` fetched out-of-band from the
-> Specialized account keystore) so the connection can run the encrypted
-> identification handshake and negotiate the protocol revision. TCU1 bikes
-> (2018 Levo) need neither — just the address and PIN.
+> AES key (`key`, a `BikeEncryptionKey`) so the connection can run the
+> encrypted identification handshake and negotiate the protocol revision.
+> This library has no account/login or network key-fetching feature of any
+> kind: the key can never be obtained over BLE, and must be supplied by the
+> caller from an external, authorized source (see *Encryption keys* below).
+> TCU1 bikes (2018 Levo) need neither — just the address and PIN.
 
 ### Stream telemetry (TCX2+)
 
@@ -27,7 +32,8 @@ from specialized_turbo import SpecializedConnection, TelemetryMonitor
 from specialized_turbo import parse_bike_info, BikeEncryptionKey
 
 async def main():
-    # bike_info comes from the BLE advertisement; key from your account.
+    # bike_info comes from the BLE advertisement; key from an external,
+    # authorized source.
     async with SpecializedConnection(
         "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
     ) as conn:
@@ -85,43 +91,89 @@ async with SpecializedConnection(
 
 ## CLI
 
-> **CLI TCX2+ support is limited.** The CLI cannot yet fetch a bike's AES key
-> from the Specialized account keystore, so commands that need the encrypted
-> identification handshake (`telemetry`, `capture`, and `read` of a TCX2+
-> field) fail with an explicit message on TCX2+ bikes. `scan`, `services`,
-> `read list`/`write list`, and TCU1 `read`/`write` work today. Use the
-> library API (`SpecializedConnection` with `bike_info=` and `key=`) for
-> TCX2+ telemetry and parameter access.
+Every command that connects to a specific bike (`telemetry`, `read`, `write`,
+`capture`) first resolves the bike's advertisement (`scan`-style, filtered by
+address) into a `BikeInfo`. TCU1 bikes need no key. TCX2+ bikes need their
+AES-128 key, supplied via:
 
-Scan for bikes:
+- `--key-file FILE`: a self-describing, versioned JSON key file (see
+  *Encryption keys* below), validated against the bike's HMI hardware/serial
+  IDs.
+
+There is no inline `--key` flag, no environment variable, and no
+account/login or network key-fetching feature of any kind: this library
+cannot obtain a TCX2+ key for you. The key can never be read over BLE --
+it must come from an external, authorized source and be placed in a key
+file yourself before running any TCX2+ command.
+
+Scan for bikes (prints a safe `BikeInfo` summary -- never any key/credential material):
 
 ```bash
 specialized-turbo scan
 specialized-turbo scan --timeout 15
 ```
 
+### Encryption keys (key-file format)
+
+A key file is a small JSON object, self-describing and bound to one
+specific bike by its HMI hardware/serial IDs:
+
+```json
+{
+  "version": 1,
+  "hmi_hw": "B.4.3",
+  "hmi_sn": "1234",
+  "key": "00112233445566778899aabbccddeeff"
+}
+```
+
+- `version`: format version; currently always `1`.
+- `hmi_hw` / `hmi_sn`: the bike's HMI hardware version and serial number, as
+  reported in its BLE advertisement (see `specialized-turbo scan`). A key
+  file whose `hmi_hw`/`hmi_sn` don't match the resolved bike is refused.
+- `key`: the derived 16-byte AES-128 key, as a 32-character lowercase hex
+  string.
+
+**Sensitivity:** the file contains secret key material -- treat it like a
+credential (restrict its permissions, don't commit it to version control,
+don't share it). Reading a key file is bounded to a small size limit and
+warns on stderr if its permissions are more permissive than `0600` on
+POSIX. On Windows there is no `os`-level equivalent of POSIX file-mode
+bits; restrict access to the file yourself (e.g. via NTFS ACLs) if that
+matters for your threat model -- this library cannot check or enforce
+file permissions on Windows.
+
+**Acquiring a key:** this library has no built-in, normal-user way to
+acquire a TCX2+ bike's key -- there is no account/login flow, and the key
+is never available over BLE. You must obtain the key yourself from an
+external, authorized source and write the key file above by hand (or with
+your own tooling) before using `--key-file`.
+
 Stream telemetry:
 
 ```bash
+specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166 --key-file vado.key.json
+specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166 --key-file vado.key.json --format json
+specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166 --key-file vado.key.json --duration 30
+
+# TCU1 (2018 Levo) bikes need no key at all:
 specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166
-specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166 --format json
-specialized-turbo telemetry DC:DD:BB:4A:D6:55 --pin 946166 --duration 30
 ```
 
 Read a single value:
 
 ```bash
 specialized-turbo read list                                             # show available fields
-specialized-turbo read battery_charge_percent DC:DD:BB:4A:D6:55 --pin 946166
-specialized-turbo read speed DC:DD:BB:4A:D6:55 --pin 946166 --format json
+specialized-turbo read battery_charge_percent DC:DD:BB:4A:D6:55 --pin 946166           # TCU1
+specialized-turbo read speed DC:DD:BB:4A:D6:55 --pin 946166 --key-file vado.key.json   # TCX2+
 ```
 
 Write a value:
 
 ```bash
 specialized-turbo write list                                            # show writable fields
-specialized-turbo write assist_level 2 DC:DD:BB:4A:D6:55 --pin 946166  # set to TRAIL
-specialized-turbo write acceleration 50 DC:DD:BB:4A:D6:55 --pin 946166 # 50% sensitivity
+specialized-turbo write assist_level 2 DC:DD:BB:4A:D6:55 --pin 946166  # TCU1: set to TRAIL
+specialized-turbo write assist_level 2 DC:DD:BB:4A:D6:55 --pin 946166 --key-file vado.key.json  # TCX2+
 ```
 
 Dump GATT services (debugging):
@@ -133,7 +185,7 @@ specialized-turbo services DC:DD:BB:4A:D6:55 --pin 946166
 Capture complete TCX writes and notifications for protocol debugging:
 
 ```bash
-specialized-turbo capture DC:DD:BB:4A:D6:55 --duration 60 > tcx-capture.tsv
+specialized-turbo capture DC:DD:BB:4A:D6:55 --duration 60 --key-file vado.key.json > tcx-capture.tsv
 ```
 
 ## Available fields

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -300,6 +300,12 @@ What the bike *does* provide during identification is the AES-CTR **IV**: the
 clear `SYSTEM_GET_NEW_VI` (`0x0A00`) response body carries the 16-byte IV.
 The session key is the backend key; the session IV is this per-connection IV.
 
+This library implements no account/login or network client of any kind for
+acquiring that key: it is a caller-supplied input (see the `key` parameter of
+`SpecializedConnection` and the CLI's `--key-file`, documented in the main
+[README](../README.md#encryption-keys-key-file-format)), obtained by the
+caller from an external, authorized source.
+
 ### Key derivation
 
 The backend `BTEncryptionInfo.key` is a 64-character base64 string. Deriving

--- a/specialized_turbo/__init__.py
+++ b/specialized_turbo/__init__.py
@@ -13,7 +13,7 @@ Quick start (TCX2+ bikes)::
 
     async def main():
         # ``bike_info`` comes from the BLE advertisement (parse_bike_info)
-        # and ``key`` from the Specialized account keystore -- a TCX2+ bike
+        # and ``key`` from an external, authorized source -- a TCX2+ bike
         # cannot be identified without both.
         async with SpecializedConnection(
             "DC:DD:BB:4A:D6:55", pin="946166", bike_info=info, key=key
@@ -26,9 +26,10 @@ Quick start (TCX2+ bikes)::
 
     asyncio.run(main())
 
-``BikeEncryptionKey`` and the keystore models import without the optional
-``aiohttp`` dependency; only the network ``KeystoreClient`` needs the
-``keystore`` extra (``pip install "specialized-turbo[keystore]"``).
+``BikeEncryptionKey`` and the keystore models are offline, local-only
+containers for key material: this library has no network client or account
+login of any kind. A TCX2+ bike's key must be supplied by the caller,
+obtained from an external, authorized source.
 """
 
 from __future__ import annotations
@@ -99,6 +100,7 @@ from .connection import (
     UnsupportedTCXOperationError as UnsupportedTCXOperationError,
     scan_for_bikes as scan_for_bikes,
     find_bike_by_address as find_bike_by_address,
+    find_advertisement_by_address as find_advertisement_by_address,
 )
 from .bike_info import (
     BikeInfo as BikeInfo,
@@ -250,6 +252,7 @@ __all__ = [
     "UnsupportedTCXOperationError",
     "scan_for_bikes",
     "find_bike_by_address",
+    "find_advertisement_by_address",
     # Advertisement parsing / identification
     "BikeInfo",
     "parse_bike_info",

--- a/specialized_turbo/cli.py
+++ b/specialized_turbo/cli.py
@@ -4,6 +4,17 @@ Command-line interface for the Specialized Turbo Vado BLE library.
 Provides subcommands for scanning, connecting, and reading telemetry.
 
 Uses ``argparse`` (no extra dependencies) with optional ``click`` upgrade path.
+
+Encryption keys (TCX2+ bikes)
+------------------------------
+A TCX2+ bike needs its AES-128 key to complete the identification
+handshake. This CLI never accepts a key inline (no ``--key`` flag, no
+environment variable) and has no account/login or network key-fetching
+feature of any kind. The key can never be obtained over BLE -- it must
+come from an external, authorized source and be supplied via
+``--key-file FILE``: a self-describing, versioned JSON key file bound to
+the bike's HMI hardware/serial IDs (see the ``--key-file`` help text for
+the exact format).
 """
 
 from __future__ import annotations
@@ -12,13 +23,23 @@ import argparse
 import asyncio
 import json
 import logging
+import os
+import re
+import stat
 import sys
 import time
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
-from .connection import scan_for_bikes, SpecializedConnection
+from .bike_info import BikeInfo, parse_bike_info
+from .connection import (
+    find_advertisement_by_address,
+    scan_for_bikes,
+    SpecializedConnection,
+)
 from .identification import IdentificationError
+from .keystore.exceptions import InvalidEncryptionKeyError
+from .keystore.models import BikeEncryptionKey
 from .parameters import all_tcx_fields
 from .protocol import (
     all_field_defs,
@@ -34,6 +55,240 @@ def _setup_logging(verbose: bool) -> None:
         level=level,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%H:%M:%S",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI-level errors
+# ---------------------------------------------------------------------------
+
+
+class BikeNotFoundError(Exception):
+    """No advertisement was seen from the requested address within the scan timeout."""
+
+
+class BikeInfoIncompleteError(Exception):
+    """The device was detected but its advertisement could not be fully decoded.
+
+    Typically an Apple-iBeacon-only or name-only detection with no Nordic
+    10-byte structured record -- the HMI hardware/serial IDs (needed for
+    identification and key binding) aren't derivable from it.
+    """
+
+
+class KeyRequiredError(Exception):
+    """A TCX2+ command needs a key but --key-file was not given."""
+
+
+class KeyFileError(Exception):
+    """Raised for any problem reading or validating a key file."""
+
+
+_CLI_ERRORS: tuple[type[Exception], ...] = (
+    BikeNotFoundError,
+    BikeInfoIncompleteError,
+    KeyRequiredError,
+    KeyFileError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bike discovery / identification resolution
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_bike_info(address: str, timeout: float) -> BikeInfo:
+    """Resolve the ``BikeInfo`` for *address* via a fresh, address-filtered scan.
+
+    Shared by every command that connects to a specific bike (``telemetry``,
+    ``read``, ``write``, ``capture``). TCU1 bikes are always
+    ``complete`` (see :func:`~specialized_turbo.bike_info.parse_bike_info`)
+    and never need a key. A TCX bike whose advertisement can't be fully
+    decoded (e.g. only the Apple iBeacon detection magic was seen, not the
+    structured Nordic record) raises :class:`BikeInfoIncompleteError` rather
+    than proceeding with unknown HMI hardware/serial IDs.
+    """
+    found = await find_advertisement_by_address(address, timeout=timeout)
+    if found is None:
+        raise BikeNotFoundError(
+            f"No advertisement received from {address} within {timeout:g}s. "
+            "Make sure the bike is powered on, awake, and within BLE range, "
+            "then try again."
+        )
+    device, adv = found
+    info = parse_bike_info(device.name or "", adv.manufacturer_data)
+
+    if info.ble_profile == BLEProfile.TCU1:
+        return info
+
+    if not info.is_bike:
+        raise BikeInfoIncompleteError(
+            f"The device at {address} does not look like a Specialized "
+            "Turbo bike (no recognized advertisement data)."
+        )
+
+    if not info.complete:
+        raise BikeInfoIncompleteError(
+            f"Advertisement from {address} was detected as a Specialized "
+            "bike but could not be fully decoded (only Apple iBeacon / "
+            "name-only detection magic was seen, not the full Nordic "
+            "advertisement record). Move closer to the bike and retry."
+        )
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Key file (self-describing, versioned JSON; bound to hmi_hw + hmi_sn)
+# ---------------------------------------------------------------------------
+#
+# Key files are produced out-of-band by an external, authorized source
+# (this library provides no account/login or network key-fetching feature
+# of any kind -- the key can never be obtained over BLE). The expected
+# JSON schema is a flat object::
+#
+#     {
+#         "version": 1,
+#         "hmi_hw": "<HMI hardware version string, e.g. \"B.4.3\">",
+#         "hmi_sn": "<HMI serial number string>",
+#         "key": "<32-character lowercase hex string; the derived 16-byte AES key>"
+#     }
+#
+# ``hmi_hw``/``hmi_sn`` bind the file to one specific bike -- a key file
+# for a different bike is refused (see :func:`_read_key_file`). The file
+# contains secret key material: treat it like a credential (restrict its
+# permissions, keep it out of version control/backups you don't control).
+
+_KEY_FILE_VERSION = 1
+_KEY_HEX_RE = re.compile(r"[0-9a-f]{32}")
+#: A genuine key file (version + hmi_hw + hmi_sn + 32-char hex key, as
+#: JSON) is well under 200 bytes; 4 KiB is a generous ceiling that still
+#: bounds memory use and rejects anything absurdly oversized outright.
+_MAX_KEY_FILE_BYTES = 4096
+
+
+def _warn_if_permissive(path: str) -> None:
+    """Warn (stderr) if *path* is readable/writable by group or other.
+
+    POSIX only -- Windows has no equivalent st_mode permission bits via
+    ``os.stat``, so this is a no-op there. On Windows, restrict access to
+    the key file yourself (e.g. via NTFS ACLs) if that matters for your
+    threat model; this CLI cannot check or enforce that for you.
+    """
+    if os.name != "posix":
+        return
+    try:
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+    except OSError:
+        return
+    if mode & 0o077:
+        print(
+            f"Warning: {path} is readable by group/other (mode "
+            f"{oct(mode)}). Consider tightening it: chmod 600 {path}",
+            file=sys.stderr,
+        )
+
+
+def _read_key_file(path: str, bike_info: BikeInfo) -> BikeEncryptionKey:
+    """Read, validate, and return the key from a self-describing key file.
+
+    Validates the file's format version and that its ``hmi_hw``/``hmi_sn``
+    binding matches *bike_info* -- a key file for a different bike is
+    refused rather than silently used. Never logs or prints the raw key.
+
+    The read is bounded to :data:`_MAX_KEY_FILE_BYTES` (a genuine key file
+    is well under 200 bytes): an oversized file is rejected outright,
+    without ever loading more than that bound into memory or echoing any
+    of its content in the error.
+    """
+    try:
+        with open(path, "rb") as fh:
+            raw_bytes = fh.read(_MAX_KEY_FILE_BYTES + 1)
+    except FileNotFoundError:
+        raise KeyFileError(f"Key file not found: {path}") from None
+    except OSError as exc:
+        raise KeyFileError(f"Could not read key file {path}: {exc}") from None
+
+    if len(raw_bytes) > _MAX_KEY_FILE_BYTES:
+        raise KeyFileError(
+            f"Key file {path} exceeds the {_MAX_KEY_FILE_BYTES}-byte limit "
+            "for a key file; refusing to read it"
+        )
+
+    _warn_if_permissive(path)
+
+    try:
+        raw_text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise KeyFileError(f"Key file {path} is not valid UTF-8 ({exc})") from None
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise KeyFileError(f"Key file {path} is not valid JSON: {exc}") from None
+
+    if not isinstance(payload, dict):
+        raise KeyFileError(f"Key file {path} must contain a JSON object")
+
+    version = payload.get("version")
+    if version != _KEY_FILE_VERSION:
+        raise KeyFileError(
+            f"Key file {path} has unsupported version {version!r} "
+            f"(expected {_KEY_FILE_VERSION})"
+        )
+
+    file_hw = payload.get("hmi_hw")
+    file_sn = payload.get("hmi_sn")
+    raw_hex = payload.get("key")
+    if (
+        not isinstance(file_hw, str)
+        or not isinstance(file_sn, str)
+        or not isinstance(raw_hex, str)
+    ):
+        raise KeyFileError(f"Key file {path} is missing required fields")
+
+    if bike_info.hmi_hardware_version != file_hw or bike_info.hmi_serial != file_sn:
+        raise KeyFileError(
+            f"Key file {path} is bound to hmi_hw={file_hw!r} "
+            f"hmi_sn={file_sn!r}, but the resolved bike identifies as "
+            f"hmi_hw={bike_info.hmi_hardware_version!r} "
+            f"hmi_sn={bike_info.hmi_serial!r}. Refusing to use a key file "
+            "for the wrong bike."
+        )
+
+    if not _KEY_HEX_RE.fullmatch(raw_hex):
+        raise KeyFileError(
+            f"Key file {path} does not contain a 32-character lowercase hex key"
+        )
+
+    try:
+        return BikeEncryptionKey(raw=raw_hex)
+    except InvalidEncryptionKeyError as exc:
+        raise KeyFileError(f"Key file {path} contains an invalid key ({exc})") from None
+
+
+async def _resolve_key(
+    bike_info: BikeInfo, args: argparse.Namespace
+) -> BikeEncryptionKey | None:
+    """Resolve the encryption key (if any) needed to connect to *bike_info*.
+
+    TCU1 bikes bypass key resolution entirely (``None``). A TCX bike needs
+    ``--key-file`` (read + HMI-bound validated); if it's not given, raises
+    :class:`KeyRequiredError`. This key can never be obtained over BLE --
+    it must come from an external, authorized source.
+    """
+    if bike_info.ble_profile == BLEProfile.TCU1:
+        return None
+
+    key_file = getattr(args, "key_file", None)
+
+    if key_file is not None:
+        return _read_key_file(key_file, bike_info)
+
+    raise KeyRequiredError(
+        "This bike requires an encryption key: pass --key-file FILE. This "
+        "key can never be obtained over BLE; it must come from an "
+        "external, authorized source."
     )
 
 
@@ -54,12 +309,25 @@ async def _cmd_scan(args: argparse.Namespace) -> None:
 
     print(f"\nFound {len(results)} bike(s):\n")
     for device, adv in results:
-        print(f"  Name:    {device.name or '(unknown)'}")
-        print(f"  Address: {device.address}")
-        print(f"  RSSI:    {adv.rssi} dBm")
-        mfr = adv.manufacturer_data.get(0x0059, b"")
-        if mfr:
-            print(f"  Mfr:     {mfr.hex()}")
+        # BikeInfo never carries key/credential material, so this summary
+        # is always safe to print in full.
+        info = parse_bike_info(device.name or "", adv.manufacturer_data)
+        print(f"  Name:      {device.name or '(unknown)'}")
+        print(f"  Address:   {device.address}")
+        print(f"  RSSI:      {adv.rssi} dBm")
+        print(f"  Bike:      {info.bike_name}")
+        print(
+            f"  Profile:   {info.ble_profile.name if info.ble_profile else 'unknown'}"
+        )
+        print(f"  Complete:  {info.complete}")
+        if info.complete:
+            print(f"  HMI type:  {info.hmi_type.name if info.hmi_type else 'unknown'}")
+            print(f"  HMI HW:    {info.hmi_hardware_version}")
+            print(f"  HMI serial:{info.hmi_serial}")
+            if info.bike_type is not None:
+                print(f"  Bike type: {info.bike_type.name}")
+            if info.system_state is not None:
+                print(f"  State:     {info.system_state.name}")
         print()
 
 
@@ -70,11 +338,18 @@ async def _cmd_scan(args: argparse.Namespace) -> None:
 
 async def _cmd_telemetry(args: argparse.Namespace) -> None:
     """Connect and stream live telemetry."""
-    print(f"Connecting to {args.address} ...")
+    print(f"Resolving {args.address} ...")
+    bike_info = await _resolve_bike_info(args.address, args.scan_timeout)
+    generation = bike_info.ble_profile or BLEProfile.TCX
+    key = await _resolve_key(bike_info, args)
 
+    print(f"Connecting to {args.address} ...")
     snapshot = await run_telemetry_session(
         args.address,
         pin=args.pin,
+        generation=generation,
+        bike_info=bike_info,
+        key=key,
         duration=args.duration,
         output_format=args.format,
     )
@@ -108,6 +383,13 @@ _TCX_FIELD_NAME_MAP: dict[str, int] = {}
 for _param_id, _tfd in all_tcx_fields().items():
     _TCX_FIELD_NAME_MAP[_tfd.name] = _param_id
 
+# Writable TCX fields: name → param id
+_TCX_WRITABLE_FIELD_MAP: dict[str, int] = {
+    name: param_id
+    for name, param_id in _TCX_FIELD_NAME_MAP.items()
+    if all_tcx_fields()[param_id].writable
+}
+
 
 async def _cmd_read(args: argparse.Namespace) -> None:
     """Connect, read a specific value, and disconnect."""
@@ -136,59 +418,101 @@ async def _cmd_read(args: argparse.Namespace) -> None:
         print("Use 'read list' to see available fields.")
         sys.exit(1)
 
-    if tcx_param_id is not None:
-        # A TCX2+ read must go through the identification handshake (which
-        # resolves the app-level BikeParameter to a revision-specific wire
-        # id). That needs the bike's advertisement (BikeInfo) and its AES key
-        # from the account keystore -- neither of which the CLI can fetch
-        # yet. Fail explicitly instead of silently addressing a raw enum id.
-        print(
-            f"Reading TCX2+ field '{field_name}' is not supported by the CLI "
-            "yet: it requires an identification handshake using the bike's "
-            "advertisement (BikeInfo) and its AES key from the Specialized "
-            "account keystore. Use the library API instead "
-            "(SpecializedConnection with bike_info= and key=, then "
-            "request_tcx_parameter)."
-        )
-        sys.exit(1)
+    print(f"Resolving {args.address} ...")
+    bike_info = await _resolve_bike_info(args.address, args.scan_timeout)
 
-    assert tcu1_key is not None
-    sender, channel = tcu1_key
-    print(f"Connecting to {args.address} to read '{field_name}' ...")
+    if tcx_param_id is not None and bike_info.ble_profile == BLEProfile.TCX:
+        tfd = all_tcx_fields()[tcx_param_id]
+        key = await _resolve_key(bike_info, args)
+        print(f"Connecting to {args.address} to read '{field_name}' ...")
+        async with SpecializedConnection(
+            args.address,
+            pin=args.pin,
+            generation=BLEProfile.TCX,
+            bike_info=bike_info,
+            key=key,
+        ) as conn:
+            msg = await conn.request_tcx_parameter(tfd.param)
+            if msg.nak_reason is not None:
+                if args.format == "json":
+                    print(
+                        json.dumps(
+                            {
+                                "field": field_name,
+                                "rejected": True,
+                                "reason": msg.nak_reason,
+                            },
+                            default=str,
+                        )
+                    )
+                else:
+                    print(
+                        f"{field_name}: rejected by bike (reason 0x{msg.nak_reason:02x})"
+                    )
+            else:
+                converted = tfd.convert(msg.value) if msg.value is not None else None
+                if args.format == "json":
+                    print(
+                        json.dumps(
+                            {
+                                "field": field_name,
+                                "value": converted,
+                                "raw": msg.value,
+                                "unit": tfd.unit,
+                            },
+                            default=str,
+                        )
+                    )
+                else:
+                    print(f"{field_name} = {converted} {tfd.unit}")
+        return
 
-    async with SpecializedConnection(
-        args.address, pin=args.pin, generation=BLEProfile.TCU1
-    ) as conn:
-        msg = await conn.request_value(sender, channel)
-        if args.format == "json":
-            if msg.nak_reason is not None:
-                print(
-                    json.dumps(
-                        {
-                            "field": field_name,
-                            "rejected": True,
-                            "reason": msg.nak_reason,
-                        },
-                        default=str,
+    if tcu1_key is not None and bike_info.ble_profile == BLEProfile.TCU1:
+        sender, channel = tcu1_key
+        print(f"Connecting to {args.address} to read '{field_name}' ...")
+
+        async with SpecializedConnection(
+            args.address, pin=args.pin, generation=BLEProfile.TCU1
+        ) as conn:
+            msg = await conn.request_value(sender, channel)
+            if args.format == "json":
+                if msg.nak_reason is not None:
+                    print(
+                        json.dumps(
+                            {
+                                "field": field_name,
+                                "rejected": True,
+                                "reason": msg.nak_reason,
+                            },
+                            default=str,
+                        )
                     )
-                )
-            else:
-                print(
-                    json.dumps(
-                        {
-                            "field": msg.field_name,
-                            "value": msg.converted_value,
-                            "raw": msg.raw_value,
-                            "unit": msg.unit,
-                        },
-                        default=str,
+                else:
+                    print(
+                        json.dumps(
+                            {
+                                "field": msg.field_name,
+                                "value": msg.converted_value,
+                                "raw": msg.raw_value,
+                                "unit": msg.unit,
+                            },
+                            default=str,
+                        )
                     )
-                )
-        else:
-            if msg.nak_reason is not None:
-                print(f"{field_name}: rejected by bike (reason 0x{msg.nak_reason:02x})")
             else:
-                print(f"{msg.field_name} = {msg.converted_value} {msg.unit}")
+                if msg.nak_reason is not None:
+                    print(
+                        f"{field_name}: rejected by bike (reason 0x{msg.nak_reason:02x})"
+                    )
+                else:
+                    print(f"{msg.field_name} = {msg.converted_value} {msg.unit}")
+        return
+
+    print(
+        f"Field '{field_name}' is not available on this bike's protocol "
+        f"({bike_info.ble_profile.name if bike_info.ble_profile else 'unknown'})."
+    )
+    sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -208,14 +532,22 @@ async def _cmd_write(args: argparse.Namespace) -> None:
 
     if field_name == "list":
         print("Writable fields:\n")
+        print("  TCU1 fields:")
         for name, (sender, channel) in sorted(_WRITABLE_FIELD_MAP.items()):
             fd = all_field_defs()[(sender, channel)]
             print(
-                f"  {name:<28s}  (sender=0x{sender:02x} channel=0x{channel:02x})  [{fd.unit}]"
+                f"    {name:<28s}  (sender=0x{sender:02x} channel=0x{channel:02x})  [{fd.unit}]"
             )
+        print("\n  TCX fields:")
+        for name, param_id in sorted(_TCX_WRITABLE_FIELD_MAP.items()):
+            tfd = all_tcx_fields()[param_id]
+            print(f"    {name:<28s}  (param={param_id})  [{tfd.unit}]")
         return
 
-    if field_name not in _WRITABLE_FIELD_MAP:
+    tcx_param_id = _TCX_WRITABLE_FIELD_MAP.get(field_name)
+    tcu1_key = _WRITABLE_FIELD_MAP.get(field_name)
+
+    if tcx_param_id is None and tcu1_key is None:
         print(f"Unknown or read-only field: {field_name}")
         print("Use 'write list' to see writable fields.")
         sys.exit(1)
@@ -224,34 +556,60 @@ async def _cmd_write(args: argparse.Namespace) -> None:
         print("Usage: specialized-turbo write <field> <value> <address>")
         sys.exit(1)
 
-    sender, channel = _WRITABLE_FIELD_MAP[field_name]
-    fd = all_field_defs()[(sender, channel)]
+    print(f"Resolving {args.address} ...")
+    bike_info = await _resolve_bike_info(args.address, args.scan_timeout)
 
-    # Parse and encode the value
-    raw_value = float(args.value) if "." in args.value else int(args.value)
-    if fd.encode is not None:
-        wire_value = fd.encode(raw_value)
-    else:
-        wire_value = int(raw_value)
+    if tcx_param_id is not None and bike_info.ble_profile == BLEProfile.TCX:
+        tfd = all_tcx_fields()[tcx_param_id]
+        raw_value = float(args.value) if "." in args.value else int(args.value)
+        wire_value = tfd.encode(raw_value) if tfd.encode is not None else int(raw_value)
+        data_bytes = wire_value.to_bytes(tfd.data_size, "little")
 
-    from .protocol import build_write_command
+        key = await _resolve_key(bike_info, args)
+        print(f"Connecting to {args.address} to write '{field_name}' = {raw_value} ...")
+        async with SpecializedConnection(
+            args.address,
+            pin=args.pin,
+            generation=BLEProfile.TCX,
+            bike_info=bike_info,
+            key=key,
+        ) as conn:
+            await conn.write_tcx_parameter(tfd.param, data_bytes)
+            print(
+                f"Wrote {field_name} = {raw_value} (raw: {wire_value}, "
+                f"bytes: {data_bytes.hex()})"
+            )
+        return
 
-    data_bytes = wire_value.to_bytes(fd.data_size, "little")
-    command = build_write_command(sender, channel, data_bytes)
+    if tcu1_key is not None and bike_info.ble_profile == BLEProfile.TCU1:
+        sender, channel = tcu1_key
+        fd = all_field_defs()[(sender, channel)]
 
-    print(f"Connecting to {args.address} to write '{field_name}' = {raw_value} ...")
+        raw_value = float(args.value) if "." in args.value else int(args.value)
+        wire_value = fd.encode(raw_value) if fd.encode is not None else int(raw_value)
 
-    # ``write list`` fields come from the TCU1 field table, so drive the
-    # write over the TCU1 profile (no identification handshake needed). A
-    # TCX2+ write must instead go through the library API's
-    # write_tcx_parameter with a fully identified connection.
-    async with SpecializedConnection(
-        args.address, pin=args.pin, generation=BLEProfile.TCU1
-    ) as conn:
-        await conn.write_command(command)
-        print(
-            f"Wrote {field_name} = {raw_value} (raw: {wire_value}, bytes: {command.hex()})"
-        )
+        from .protocol import build_write_command
+
+        data_bytes = wire_value.to_bytes(fd.data_size, "little")
+        command = build_write_command(sender, channel, data_bytes)
+
+        print(f"Connecting to {args.address} to write '{field_name}' = {raw_value} ...")
+
+        async with SpecializedConnection(
+            args.address, pin=args.pin, generation=BLEProfile.TCU1
+        ) as conn:
+            await conn.write_command(command)
+            print(
+                f"Wrote {field_name} = {raw_value} (raw: {wire_value}, "
+                f"bytes: {command.hex()})"
+            )
+        return
+
+    print(
+        f"Field '{field_name}' is not available on this bike's protocol "
+        f"({bike_info.ble_profile.name if bike_info.ble_profile else 'unknown'})."
+    )
+    sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +647,11 @@ async def _cmd_services(args: argparse.Namespace) -> None:
 
 async def _cmd_capture(args: argparse.Namespace) -> None:
     """Capture complete TCX writes and notifications as tab-separated hex."""
+    print(f"Resolving {args.address} ...")
+    bike_info = await _resolve_bike_info(args.address, args.scan_timeout)
+    generation = bike_info.ble_profile or BLEProfile.TCX
+    key = await _resolve_key(bike_info, args)
+
     started = time.monotonic()
 
     def trace(event: BLETraceEvent) -> None:
@@ -309,6 +672,9 @@ async def _cmd_capture(args: argparse.Namespace) -> None:
     async with SpecializedConnection(
         args.address,
         pin=args.pin,
+        generation=generation,
+        bike_info=bike_info,
+        key=key,
         trace_callback=trace,
     ) as conn:
         await conn.subscribe_notifications(discard)
@@ -326,23 +692,57 @@ async def _cmd_capture(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _add_key_args(parser: argparse.ArgumentParser) -> None:
+    """Add the --key-file/--scan-timeout options shared by every command
+    that connects to a specific bike.
+
+    No inline key argument and no environment variable are ever accepted,
+    and this CLI has no account/login or network key-fetching feature of
+    any kind -- the key can never be obtained over BLE. It must be
+    supplied via a key file (validated against the bike's HMI binding),
+    produced out-of-band from an external, authorized source.
+    """
+    parser.add_argument(
+        "--key-file",
+        type=str,
+        default=None,
+        help=(
+            "Path to a versioned JSON key file bound to the bike's HMI "
+            "hardware/serial IDs (TCX2+ only). Obtain this from an "
+            "external, authorized source -- it can never be fetched over "
+            "BLE."
+        ),
+    )
+    parser.add_argument(
+        "--scan-timeout",
+        type=float,
+        default=10.0,
+        help="Timeout (seconds) for resolving the bike's advertisement",
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="specialized-turbo",
         description="Interact with Specialized Turbo e-bikes over Bluetooth LE",
+        allow_abbrev=False,
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Debug logging")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
     # --- scan ---
-    p_scan = sub.add_parser("scan", help="Scan for nearby Specialized bikes")
+    p_scan = sub.add_parser(
+        "scan", help="Scan for nearby Specialized bikes", allow_abbrev=False
+    )
     p_scan.add_argument(
         "-t", "--timeout", type=float, default=10.0, help="Scan duration (seconds)"
     )
 
     # --- telemetry ---
-    p_tel = sub.add_parser("telemetry", help="Stream live telemetry")
+    p_tel = sub.add_parser(
+        "telemetry", help="Stream live telemetry", allow_abbrev=False
+    )
     p_tel.add_argument("address", help="BLE MAC address (e.g. DC:DD:BB:4A:D6:55)")
     p_tel.add_argument("-p", "--pin", type=str, default=None, help="Pairing PIN")
     p_tel.add_argument(
@@ -353,18 +753,24 @@ def main(argv: list[str] | None = None) -> None:
         help="Duration in seconds (0=forever)",
     )
     p_tel.add_argument("-f", "--format", choices=["table", "json"], default="table")
+    _add_key_args(p_tel)
 
     # --- read ---
     p_read = sub.add_parser(
-        "read", help="Read a specific value (use 'read list' to see fields)"
+        "read",
+        help="Read a specific value (use 'read list' to see fields)",
+        allow_abbrev=False,
     )
     p_read.add_argument("field", help="Field name or 'list'")
     p_read.add_argument("address", nargs="?", default=None, help="BLE MAC address")
     p_read.add_argument("-p", "--pin", type=str, default=None, help="Pairing PIN")
     p_read.add_argument("-f", "--format", choices=["table", "json"], default="table")
+    _add_key_args(p_read)
 
     # --- services ---
-    p_svc = sub.add_parser("services", help="Enumerate GATT services (debug)")
+    p_svc = sub.add_parser(
+        "services", help="Enumerate GATT services (debug)", allow_abbrev=False
+    )
     p_svc.add_argument("address", help="BLE MAC address")
     p_svc.add_argument("-p", "--pin", type=str, default=None, help="Pairing PIN")
 
@@ -372,6 +778,7 @@ def main(argv: list[str] | None = None) -> None:
     p_capture = sub.add_parser(
         "capture",
         help="Capture raw TCX writes and notifications",
+        allow_abbrev=False,
     )
     p_capture.add_argument("address", help="BLE MAC address")
     p_capture.add_argument("-p", "--pin", type=str, default=None, help="Pairing PIN")
@@ -382,16 +789,19 @@ def main(argv: list[str] | None = None) -> None:
         default=60,
         help="Capture duration in seconds (0=forever)",
     )
+    _add_key_args(p_capture)
 
     # --- write ---
     p_write = sub.add_parser(
         "write",
         help="Write a value to the bike (use 'write list' to see writable fields)",
+        allow_abbrev=False,
     )
     p_write.add_argument("field", help="Field name or 'list'")
     p_write.add_argument("value", nargs="?", default=None, help="Value to write")
     p_write.add_argument("address", nargs="?", default=None, help="BLE MAC address")
     p_write.add_argument("-p", "--pin", type=str, default=None, help="Pairing PIN")
+    _add_key_args(p_write)
 
     args = parser.parse_args(argv)
     _setup_logging(args.verbose)
@@ -410,17 +820,10 @@ def main(argv: list[str] | None = None) -> None:
     except KeyboardInterrupt:
         print("\nInterrupted.")
     except IdentificationError as exc:
-        # A TCX2+ command reached the identification handshake but could not
-        # complete it (typically no BikeInfo/key). Surface a clear, typed
-        # failure instead of an opaque traceback or AttributeError.
         print(f"\nError: {exc}")
-        print(
-            "TCX2+ bikes require an identification handshake using the bike's "
-            "advertisement (BikeInfo) and its AES key from the Specialized "
-            "account keystore. The CLI cannot fetch these yet, so connecting "
-            "to a TCX bike is not supported from the CLI. Use the library API "
-            "(SpecializedConnection with bike_info= and key=)."
-        )
+        sys.exit(1)
+    except _CLI_ERRORS as exc:
+        print(f"\nError: {exc}")
         sys.exit(1)
 
 

--- a/specialized_turbo/connection.py
+++ b/specialized_turbo/connection.py
@@ -16,7 +16,7 @@ from bleak import BleakClient, BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
-from .bike_info import BikeInfo
+from .bike_info import BikeInfo, parse_bike_info
 from .identification import (
     IdentificationResult,
     TCXIdentification,
@@ -104,6 +104,111 @@ async def find_bike_by_address(
     return device
 
 
+def _merge_advertisement_data(
+    merged: AdvertisementData | None, adv: AdvertisementData
+) -> AdvertisementData:
+    """Fold a new ``AdvertisementData`` event into the running merged report.
+
+    Manufacturer/service data are merged key-by-key (a later event's bytes
+    for a given company/service id win), service UUIDs are unioned, and
+    the local name/tx power are taken from the latest event that actually
+    carries a non-``None`` value (an event with no name/tx power must not
+    blank out one already seen). RSSI and platform data are always taken
+    from the latest event -- there is no "missing" sentinel for either.
+    """
+    if merged is None:
+        return AdvertisementData(
+            local_name=adv.local_name,
+            manufacturer_data=dict(adv.manufacturer_data),
+            service_data=dict(adv.service_data),
+            service_uuids=list(dict.fromkeys(adv.service_uuids)),
+            tx_power=adv.tx_power,
+            rssi=adv.rssi,
+            platform_data=adv.platform_data,
+        )
+    return AdvertisementData(
+        local_name=adv.local_name if adv.local_name is not None else merged.local_name,
+        manufacturer_data={**merged.manufacturer_data, **adv.manufacturer_data},
+        service_data={**merged.service_data, **adv.service_data},
+        service_uuids=list(dict.fromkeys([*merged.service_uuids, *adv.service_uuids])),
+        tx_power=adv.tx_power if adv.tx_power is not None else merged.tx_power,
+        rssi=adv.rssi,
+        platform_data=adv.platform_data,
+    )
+
+
+async def find_advertisement_by_address(
+    address: str,
+    timeout: float = 10.0,
+) -> tuple[BLEDevice, AdvertisementData] | None:
+    """Scan for a specific device by MAC address, preserving its ``AdvertisementData``.
+
+    Unlike :func:`find_bike_by_address` (which wraps ``BleakScanner.
+    find_device_by_address`` and only returns a ``BLEDevice``), this keeps
+    the matching advertisement's manufacturer data so callers can parse it
+    into a :class:`~specialized_turbo.bike_info.BikeInfo` (e.g. to resolve
+    the HMI hardware/serial IDs needed to identify a TCX2+ bike or bind an
+    encryption key) without a second, separate scan.
+
+    Some backends -- WinRT in particular (see `issue #9
+    <https://github.com/JamieMagee/specialized-turbo/issues/9>`_) -- split a
+    single physical advertisement into several separate
+    ``detection_callback`` events for the *same* address, e.g. an initial
+    event with an empty name and no manufacturer data, followed later by
+    one carrying the device's local name and the Nordic/Simplo
+    manufacturer bytes. Returning whichever event happens to arrive first
+    can hand callers an empty, unparseable report even though the bike
+    *was* seen. This function instead merges every matching-address event
+    across the whole scan (see :func:`_merge_advertisement_data`) and
+    resolves as soon as the merged manufacturer data parses -- via
+    :func:`~specialized_turbo.bike_info.parse_bike_info` -- into a
+    *complete* ``BikeInfo`` (a TCU1 record, or a full 10-byte Nordic
+    record). Otherwise it keeps scanning until *timeout* and returns the
+    best merged report seen so far, which may still be incomplete (e.g. an
+    Apple-iBeacon-only advertisement stays distinguishable from a fully
+    decoded one). Returns ``None`` only if *no* event from *address* was
+    seen at all within *timeout* seconds.
+    """
+    loop = asyncio.get_running_loop()
+    resolved: asyncio.Future[None] = loop.create_future()
+
+    merged_device: BLEDevice | None = None
+    merged_adv: AdvertisementData | None = None
+
+    def _detection_callback(device: BLEDevice, adv: AdvertisementData) -> None:
+        nonlocal merged_device, merged_adv
+        if device.address.lower() != address.lower():
+            return
+        # Same "retain latest non-None" rule as local_name/tx_power below:
+        # a later event with no OS-cached name yet must not blank out one
+        # already seen from an earlier event for this address.
+        if merged_device is None or device.name is not None:
+            merged_device = device
+        merged_adv = _merge_advertisement_data(merged_adv, adv)
+        if not resolved.done():
+            info = parse_bike_info(
+                merged_device.name or "", merged_adv.manufacturer_data
+            )
+            if info.complete:
+                resolved.set_result(None)
+
+    scanner = BleakScanner(detection_callback=_detection_callback)
+    await scanner.start()
+    try:
+        try:
+            await asyncio.wait_for(asyncio.shield(resolved), timeout=timeout)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+    finally:
+        await scanner.stop()
+        if not resolved.done():
+            resolved.cancel()
+
+    if merged_device is None or merged_adv is None:
+        return None
+    return merged_device, merged_adv
+
+
 # ---------------------------------------------------------------------------
 # Connection
 # ---------------------------------------------------------------------------
@@ -115,7 +220,7 @@ class SpecializedConnection:
 
     TCX2+ bikes require the pre-connect advertisement parse (*bike_info*, see
     :func:`specialized_turbo.bike_info.parse_bike_info`) and the AES key
-    fetched out-of-band from the account keystore (*key*, a
+    obtained from an external, authorized source (*key*, a
     :class:`~specialized_turbo.keystore.models.BikeEncryptionKey`) so the
     official identification handshake can run and negotiate the protocol
     revision. TCU1 bikes need neither. Usage::
@@ -161,8 +266,9 @@ class SpecializedConnection:
             (:class:`~specialized_turbo.identification.TCXIdentification`)
             can select the right wire-id map.  Ignored for TCU1.
         key :
-            The bike's AES-128 encryption key, fetched out-of-band from the
-            account keystore (never available over BLE). Required for a
+            The bike's AES-128 encryption key. This key can never be
+            obtained over BLE; it must come from an external, authorized
+            source (e.g. a key file supplied out-of-band). Required for a
             TCX connection, since every complete TCX ``BikeInfo`` implies
             AES-CTR encryption. Never logged -- see
             :class:`~specialized_turbo.keystore.models.BikeEncryptionKey`.

--- a/specialized_turbo/coordinator_helpers.py
+++ b/specialized_turbo/coordinator_helpers.py
@@ -300,8 +300,9 @@ async def identify_tcx(
 
        New code should use :class:`specialized_turbo.identification.TCXIdentification`
        (or the :func:`specialized_turbo.identification.identify` convenience
-       wrapper), which fetches the real key from the account keystore and
-       negotiates generation/revision-correct wire ids.
+       wrapper), which uses the caller-supplied key (obtained from an
+       external, authorized source) and negotiates generation/revision-correct
+       wire ids.
        :class:`~specialized_turbo.connection.SpecializedConnection` no longer
        calls this shim -- it drives ``TCXIdentification`` directly.  This
        function is retained only for backward compatibility with any

--- a/specialized_turbo/identification.py
+++ b/specialized_turbo/identification.py
@@ -3,23 +3,24 @@ Official TCX2+ identification protocol (post-connect, encrypted).
 
 This is the profile-aware identification **state machine** that a connection
 layer drives after a BLE link is established and (for encrypted bikes) the
-AES key has been fetched out-of-band from the account keystore.  It ties
-together the previously-added foundation layers -- :mod:`bike_info`,
-:mod:`wire_profiles`, :mod:`keystore`, :mod:`transport`/:mod:`session`/
-:mod:`encryption` -- into one tested unit.  It does **not** open a BLE
-connection, scan, pair, or start telemetry; those remain the caller's job.
+AES key has been supplied by the caller, obtained from an external,
+authorized source.  It ties together the previously-added foundation layers
+-- :mod:`bike_info`, :mod:`wire_profiles`, :mod:`keystore`,
+:mod:`transport`/:mod:`session`/:mod:`encryption` -- into one tested unit.
+It does **not** open a BLE connection, scan, pair, or start telemetry;
+those remain the caller's job.
 
 Corrected facts this layer encodes (superseding the earlier, buggy
 ``coordinator_helpers.identify_tcx`` flow, which is kept only as a legacy
 shim):
 
-- The AES key is **never** read over BLE.  It comes from the account
-  keystore (:class:`specialized_turbo.keystore.models.BikeEncryptionKey`).
+- The AES key is **never** read over BLE.  It must come from an external,
+  authorized source (:class:`specialized_turbo.keystore.models.BikeEncryptionKey`).
   In particular TCX parameter 14 (``BATTERY1_FIRMWARE``) is a 3-byte
   firmware version string, *not* key material.
 - ``SYSTEM_GET_NEW_VI`` (wire ``0x0A00``) is a **clear** control frame whose
   request carries a single required zero byte and whose response body is the
-  16-byte AES-CTR **IV**.  The IV plus the keystore key are what initialise
+  16-byte AES-CTR **IV**.  The IV plus the supplied key are what initialise
   the encrypted session -- no key is exchanged here.
 - ``SYSTEM_HMI_PROTOCOL_VERSION`` (wire ``0x0A01``) is a **clear** control
   frame whose response carries the bike's BLE and USB protocol revision
@@ -113,8 +114,8 @@ class UnsupportedRevisionError(IdentificationError):
 class MissingEncryptionKeyError(IdentificationError):
     """No :class:`BikeEncryptionKey` was supplied for an encrypted bike.
 
-    The key must be fetched out-of-band from the account keystore; it is
-    never available over BLE.
+    The key can never be obtained over BLE; it must come from an external,
+    authorized source (e.g. a key file supplied out-of-band).
     """
 
 
@@ -306,8 +307,8 @@ class TCXIdentification:
 
     The *transport* must already be connected (and, on real bikes, paired).
     *bike_info* is the complete pre-connect advertisement parse (its
-    ``tcx_generation`` selects the wire map); *key* is the AES key fetched
-    from the account keystore.  Call :meth:`run` once.
+    ``tcx_generation`` selects the wire map); *key* is the AES key obtained
+    from an external, authorized source.  Call :meth:`run` once.
     """
 
     def __init__(
@@ -405,8 +406,9 @@ class TCXIdentification:
             )
         if self._key is None:
             raise MissingEncryptionKeyError(
-                "No encryption key supplied; fetch it from the account "
-                "keystore (it is never available over BLE)"
+                "No encryption key supplied. This key can never be obtained "
+                "over BLE; it must come from an external, authorized source "
+                "(e.g. a key file supplied out-of-band)."
             )
         return generation, self._key
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,776 @@
+"""
+Tests for specialized_turbo.cli.
+
+Covers: key-file read (validation, HMI binding, permission warning, size
+bound), bike/BikeInfo resolution (not-found, incomplete/Apple-only, TCU1
+bypass), no-inline-key/no-fetch-key CLI flags, and the TCX/TCU1
+read/write/telemetry/capture command paths. No real BLE or network
+traffic is used anywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+import pytest
+
+import specialized_turbo.cli as cli
+from specialized_turbo.bike_info import BikeInfo, HmiType, ProtocolEncryptionMethod
+from specialized_turbo.identification import WireMessage
+from specialized_turbo.keystore.models import BikeEncryptionKey
+from specialized_turbo.parameters import BikeParameter
+from specialized_turbo.protocol import BLEProfile, ParsedMessage
+from specialized_turbo.wire_profiles import TCXGeneration
+
+RAW_KEY_HEX = "00112233445566778899aabbccddeeff"[:32]
+RAW_KEY = bytes.fromhex(RAW_KEY_HEX)
+HMI_HW = "B.4.3"  # valid TCU2-category hardware version (see _hmi_compat_data)
+HMI_SN = "1234"
+
+
+def _nordic_payload(
+    hmi_sn: str = HMI_SN, bike_type: int = 3, system_state: int = 1
+) -> bytes:
+    """Build a valid 10-byte Nordic advertisement record for HMI_HW/HMI_SN."""
+    serial = int(hmi_sn).to_bytes(4, "little")
+    hw = HMI_HW.replace(".", "").encode("latin-1")
+    assert len(hw) == 3
+    return serial + hw + b"\x00" + bytes([bike_type, system_state])
+
+
+def _tcx_bike_info(*, hmi_hw: str = HMI_HW, hmi_sn: str = HMI_SN) -> BikeInfo:
+    return BikeInfo(
+        name="SPECIALIZED",
+        bike_name="LEVO2 SPECIALIZED",
+        is_bike=True,
+        complete=True,
+        hmi_serial=hmi_sn,
+        hmi_hardware_version=hmi_hw,
+        hmi_type=HmiType.TCU2,
+        ble_profile=BLEProfile.TCX,
+        tcx_generation=TCXGeneration.TCX2,
+        encryption_method=ProtocolEncryptionMethod.AES_CTR,
+    )
+
+
+def _tcu1_bike_info() -> BikeInfo:
+    return BikeInfo(
+        name="SPECIALIZED",
+        bike_name="TURBO SPECIALIZED",
+        is_bike=True,
+        complete=True,
+        hmi_type=HmiType.TCU1,
+        ble_profile=BLEProfile.TCU1,
+        tcx_generation=None,
+        encryption_method=ProtocolEncryptionMethod.NONE,
+    )
+
+
+def _incomplete_bike_info() -> BikeInfo:
+    return BikeInfo(
+        name="SPECIALIZED",
+        bike_name="SPECIALIZED",
+        is_bike=True,
+        complete=False,
+        ble_profile=BLEProfile.TCX,
+    )
+
+
+def _not_bike_info() -> BikeInfo:
+    return BikeInfo(
+        name="Random Device", bike_name="Random Device", is_bike=False, complete=False
+    )
+
+
+def _namespace(**kwargs: Any) -> argparse.Namespace:
+    defaults = {"key_file": None}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Key file: read (validation, HMI binding, permission warning)
+# ---------------------------------------------------------------------------
+
+
+class TestReadKeyFile:
+    def _write_valid(
+        self, path, hmi_hw=HMI_HW, hmi_sn=HMI_SN, key_hex=RAW_KEY_HEX, version=1
+    ):
+        payload = {
+            "version": version,
+            "hmi_hw": hmi_hw,
+            "hmi_sn": hmi_sn,
+            "key": key_hex,
+        }
+        path.write_text(json.dumps(payload))
+
+    def test_read_valid_file_returns_matching_key(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path)
+
+        key = cli._read_key_file(str(path), _tcx_bike_info())
+
+        assert isinstance(key, BikeEncryptionKey)
+        assert key.raw == RAW_KEY
+
+    def test_read_missing_file_raises(self, tmp_path):
+        with pytest.raises(cli.KeyFileError, match="not found"):
+            cli._read_key_file(str(tmp_path / "missing.json"), _tcx_bike_info())
+
+    def test_read_invalid_json_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        path.write_text("{ not json")
+
+        with pytest.raises(cli.KeyFileError, match="not valid JSON"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_non_object_json_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        path.write_text("[1, 2, 3]")
+
+        with pytest.raises(cli.KeyFileError, match="JSON object"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_wrong_version_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, version=2)
+
+        with pytest.raises(cli.KeyFileError, match="version"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    @pytest.mark.parametrize("missing_field", ["hmi_hw", "hmi_sn", "key"])
+    def test_read_missing_field_raises(self, tmp_path, missing_field):
+        path = tmp_path / "key.json"
+        payload = {"version": 1, "hmi_hw": HMI_HW, "hmi_sn": HMI_SN, "key": RAW_KEY_HEX}
+        del payload[missing_field]
+        path.write_text(json.dumps(payload))
+
+        with pytest.raises(cli.KeyFileError, match="missing required fields"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_hmi_hw_mismatch_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, hmi_hw="X.1.1")
+
+        with pytest.raises(cli.KeyFileError, match="wrong bike"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_hmi_sn_mismatch_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, hmi_sn="9999")
+
+        with pytest.raises(cli.KeyFileError, match="wrong bike"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_non_hex_key_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, key_hex="not-hex-not-hex-not-hex-not-hex")
+
+        with pytest.raises(cli.KeyFileError, match="lowercase hex"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_uppercase_hex_key_rejected(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, key_hex=RAW_KEY_HEX.upper())
+
+        with pytest.raises(cli.KeyFileError, match="lowercase hex"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_short_key_raises(self, tmp_path):
+        path = tmp_path / "key.json"
+        self._write_valid(path, key_hex="aabb")
+
+        with pytest.raises(cli.KeyFileError):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_never_prints_key(self, tmp_path, capsys):
+        path = tmp_path / "key.json"
+        self._write_valid(path)
+
+        cli._read_key_file(str(path), _tcx_bike_info())
+
+        captured = capsys.readouterr()
+        assert RAW_KEY_HEX not in captured.out
+        assert RAW_KEY_HEX not in captured.err
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file mode only")
+    def test_read_warns_on_permissive_mode(self, tmp_path, capsys):
+        path = tmp_path / "key.json"
+        self._write_valid(path)
+        os.chmod(path, 0o644)
+
+        cli._read_key_file(str(path), _tcx_bike_info())
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert str(path) in captured.err
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file mode only")
+    def test_read_does_not_warn_on_0600(self, tmp_path, capsys):
+        path = tmp_path / "key.json"
+        self._write_valid(path)
+        os.chmod(path, 0o600)
+
+        cli._read_key_file(str(path), _tcx_bike_info())
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+    def test_read_rejects_oversized_file(self, tmp_path):
+        path = tmp_path / "key.json"
+        # Valid JSON shape, but padded with a huge extra field so the file
+        # itself exceeds the bound -- must be rejected outright.
+        payload = {
+            "version": 1,
+            "hmi_hw": HMI_HW,
+            "hmi_sn": HMI_SN,
+            "key": RAW_KEY_HEX,
+            "padding": "x" * (cli._MAX_KEY_FILE_BYTES + 1024),
+        }
+        path.write_text(json.dumps(payload))
+        assert path.stat().st_size > cli._MAX_KEY_FILE_BYTES
+
+        with pytest.raises(cli.KeyFileError, match="exceeds"):
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+    def test_read_oversized_file_error_does_not_echo_content(self, tmp_path):
+        path = tmp_path / "key.json"
+        marker = "SENTINEL-" + "y" * cli._MAX_KEY_FILE_BYTES
+        path.write_text(marker)
+
+        with pytest.raises(cli.KeyFileError) as excinfo:
+            cli._read_key_file(str(path), _tcx_bike_info())
+
+        assert marker not in str(excinfo.value)
+        assert "SENTINEL" not in str(excinfo.value)
+
+    def test_read_at_exactly_the_limit_is_accepted(self, tmp_path):
+        # A file whose content is *exactly* the bound (padded via JSON
+        # whitespace) must still be read normally -- only content
+        # strictly larger than the bound is rejected.
+        path = tmp_path / "key.json"
+        payload = {
+            "version": 1,
+            "hmi_hw": HMI_HW,
+            "hmi_sn": HMI_SN,
+            "key": RAW_KEY_HEX,
+        }
+        body = json.dumps(payload)
+        padded = body + " " * (cli._MAX_KEY_FILE_BYTES - len(body.encode("utf-8")))
+        assert len(padded.encode("utf-8")) == cli._MAX_KEY_FILE_BYTES
+        path.write_text(padded)
+
+        key = cli._read_key_file(str(path), _tcx_bike_info())
+        assert key.raw == RAW_KEY
+
+
+# ---------------------------------------------------------------------------
+# _resolve_bike_info
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBikeInfo:
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self, monkeypatch):
+        async def _fake_find(address, timeout):
+            return None
+
+        monkeypatch.setattr(cli, "find_advertisement_by_address", _fake_find)
+
+        with pytest.raises(cli.BikeNotFoundError, match="No advertisement"):
+            await cli._resolve_bike_info("AA:BB:CC:DD:EE:FF", 5.0)
+
+    @pytest.mark.asyncio
+    async def test_tcu1_bypasses_completeness_check(self, monkeypatch):
+        device = argparse.Namespace(name="SPECIALIZED", address="AA:BB:CC:DD:EE:FF")
+        adv = argparse.Namespace(manufacturer_data={0x020D: b"\x01"})
+
+        async def _fake_find(address, timeout):
+            return device, adv
+
+        monkeypatch.setattr(cli, "find_advertisement_by_address", _fake_find)
+
+        info = await cli._resolve_bike_info("AA:BB:CC:DD:EE:FF", 5.0)
+        assert info.ble_profile == BLEProfile.TCU1
+        assert info.complete is True
+
+    @pytest.mark.asyncio
+    async def test_complete_tcx_bike_returned(self, monkeypatch):
+        device = argparse.Namespace(name="SPECIALIZED", address="AA:BB:CC:DD:EE:FF")
+        adv = argparse.Namespace(manufacturer_data={0x0059: _nordic_payload()})
+
+        async def _fake_find(address, timeout):
+            return device, adv
+
+        monkeypatch.setattr(cli, "find_advertisement_by_address", _fake_find)
+
+        info = await cli._resolve_bike_info("AA:BB:CC:DD:EE:FF", 5.0)
+        assert info.ble_profile == BLEProfile.TCX
+        assert info.complete is True
+        assert info.hmi_serial == HMI_SN
+
+    @pytest.mark.asyncio
+    async def test_incomplete_apple_only_raises_clear_retry_error(self, monkeypatch):
+        # Detected as a bike by name, but only Apple iBeacon manufacturer
+        # data is present -- no Nordic 10-byte structured record, so the
+        # result is is_bike=True, complete=False.
+        device = argparse.Namespace(name="SPECIALIZED", address="AA:BB:CC:DD:EE:FF")
+        adv = argparse.Namespace(
+            manufacturer_data={0x004C: b"\x02\x15" + b"TURBOHMI2017"[:12]}
+        )
+
+        async def _fake_find(address, timeout):
+            return device, adv
+
+        monkeypatch.setattr(cli, "find_advertisement_by_address", _fake_find)
+
+        with pytest.raises(cli.BikeInfoIncompleteError, match="Move closer"):
+            await cli._resolve_bike_info("AA:BB:CC:DD:EE:FF", 5.0)
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_device_raises(self, monkeypatch):
+        device = argparse.Namespace(name="Random Device", address="AA:BB:CC:DD:EE:FF")
+        adv = argparse.Namespace(manufacturer_data={})
+
+        async def _fake_find(address, timeout):
+            return device, adv
+
+        monkeypatch.setattr(cli, "find_advertisement_by_address", _fake_find)
+
+        with pytest.raises(cli.BikeInfoIncompleteError, match="does not look like"):
+            await cli._resolve_bike_info("AA:BB:CC:DD:EE:FF", 5.0)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveKey:
+    @pytest.mark.asyncio
+    async def test_tcu1_bypasses_key(self):
+        key = await cli._resolve_key(_tcu1_bike_info(), _namespace())
+        assert key is None
+
+    @pytest.mark.asyncio
+    async def test_key_file_used_when_given(self, tmp_path):
+        path = tmp_path / "key.json"
+        payload = {"version": 1, "hmi_hw": HMI_HW, "hmi_sn": HMI_SN, "key": RAW_KEY_HEX}
+        path.write_text(json.dumps(payload))
+
+        key = await cli._resolve_key(_tcx_bike_info(), _namespace(key_file=str(path)))
+
+        assert key is not None
+        assert key.raw == RAW_KEY
+
+    @pytest.mark.asyncio
+    async def test_neither_given_raises(self):
+        with pytest.raises(cli.KeyRequiredError, match="--key-file"):
+            await cli._resolve_key(_tcx_bike_info(), _namespace())
+
+
+# ---------------------------------------------------------------------------
+# argparse: no inline --key flag, no --fetch-key/fetch-key backend command
+# ---------------------------------------------------------------------------
+
+
+class TestArgparse:
+    def test_no_inline_key_flag_exists(self, capsys):
+        with pytest.raises(SystemExit):
+            cli.main(["telemetry", "AA:BB:CC:DD:EE:FF", "--key", "deadbeef"])
+        captured = capsys.readouterr()
+        assert "unrecognized" in captured.err
+
+    def test_no_fetch_key_flag_exists(self, capsys):
+        with pytest.raises(SystemExit):
+            cli.main(["telemetry", "AA:BB:CC:DD:EE:FF", "--fetch-key"])
+        captured = capsys.readouterr()
+        assert "unrecognized" in captured.err
+
+    def test_no_fetch_key_command_exists(self, capsys):
+        with pytest.raises(SystemExit):
+            cli.main(["fetch-key", "AA:BB:CC:DD:EE:FF"])
+        captured = capsys.readouterr()
+        assert "invalid choice" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# scan: prints a safe BikeInfo summary
+# ---------------------------------------------------------------------------
+
+
+class TestCmdScan:
+    @pytest.mark.asyncio
+    async def test_scan_prints_bikeinfo_summary(self, monkeypatch, capsys):
+        device = argparse.Namespace(name="SPECIALIZED", address="AA:BB:CC:DD:EE:FF")
+        adv = argparse.Namespace(
+            manufacturer_data={0x0059: _nordic_payload()}, rssi=-55
+        )
+
+        async def _fake_scan(timeout):
+            return [(device, adv)]
+
+        monkeypatch.setattr(cli, "scan_for_bikes", _fake_scan)
+
+        await cli._cmd_scan(argparse.Namespace(timeout=5.0))
+
+        out = capsys.readouterr().out
+        assert "AA:BB:CC:DD:EE:FF" in out
+        assert "Profile:" in out
+        assert "HMI HW:" in out
+        assert "HMI serial:" in out
+        # Never any key/credential material -- BikeInfo carries none.
+        assert "key" not in out.lower()
+        assert "password" not in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# read/write/telemetry/capture: TCX + TCU1 command paths
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnection:
+    """Stand-in for SpecializedConnection used by connection-establishing commands."""
+
+    instances: list[_FakeConnection] = []
+
+    def __init__(
+        self,
+        address,
+        *,
+        pin=None,
+        generation: BLEProfile | None = None,
+        bike_info: BikeInfo | None = None,
+        key: BikeEncryptionKey | None = None,
+        trace_callback=None,
+        **kwargs,
+    ):
+        self.address = address
+        self.pin = pin
+        self.generation = generation
+        self.bike_info = bike_info
+        self.key = key
+        self.trace_callback = trace_callback
+        self.tcx_responses: dict[BikeParameter, WireMessage] = {}
+        self.tcu1_responses: dict[tuple[int, int], ParsedMessage] = {}
+        self.written_tcx: list[tuple[BikeParameter, bytes]] = []
+        self.written_tcu1: list[bytes] = []
+        _FakeConnection.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def request_tcx_parameter(self, param, *, timeout=None):
+        return self.tcx_responses[param]
+
+    async def write_tcx_parameter(self, param, data):
+        self.written_tcx.append((param, bytes(data)))
+
+    async def request_value(self, sender, channel):
+        return self.tcu1_responses[(sender, channel)]
+
+    async def write_command(self, data):
+        self.written_tcu1.append(bytes(data))
+
+    async def subscribe_notifications(self, callback):
+        pass
+
+    async def unsubscribe_notifications(self):
+        pass
+
+
+@pytest.fixture
+def fake_connection(monkeypatch):
+    _FakeConnection.instances = []
+    monkeypatch.setattr(cli, "SpecializedConnection", _FakeConnection)
+    return _FakeConnection
+
+
+@pytest.fixture
+def resolved_tcx_bike(monkeypatch):
+    async def _fake_resolve(address, timeout):
+        return _tcx_bike_info()
+
+    monkeypatch.setattr(cli, "_resolve_bike_info", _fake_resolve)
+
+
+@pytest.fixture
+def resolved_tcu1_bike(monkeypatch):
+    async def _fake_resolve(address, timeout):
+        return _tcu1_bike_info()
+
+    monkeypatch.setattr(cli, "_resolve_bike_info", _fake_resolve)
+
+
+@pytest.fixture
+def ephemeral_key(monkeypatch):
+    async def _fake_key(bike_info, args):
+        if bike_info.ble_profile == BLEProfile.TCU1:
+            return None
+        return BikeEncryptionKey(raw=RAW_KEY)
+
+    monkeypatch.setattr(cli, "_resolve_key", _fake_key)
+
+
+class TestCmdReadTCX:
+    @pytest.mark.asyncio
+    async def test_reads_tcx_field(
+        self, fake_connection, resolved_tcx_bike, ephemeral_key, capsys, monkeypatch
+    ):
+        param = cli._TCX_FIELD_NAME_MAP["battery_charge_percent"]
+        param_enum = BikeParameter(param)
+
+        # Patch request_tcx_parameter response after connection is created:
+        # use a subclass hook via instances list post-hoc is awkward, so
+        # pre-seed via a connection factory closure instead.
+        def _factory(address, **kwargs):
+            conn = _FakeConnection(address, **kwargs)
+            conn.tcx_responses[param_enum] = WireMessage(
+                wire_id=0x1234,
+                parameter=param_enum,
+                data=b"\x32",
+                value=50,
+                nak_reason=None,
+            )
+            return conn
+
+        monkeypatch.setattr(cli, "SpecializedConnection", _factory)
+
+        args = argparse.Namespace(
+            field="battery_charge_percent",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_read(args)
+
+        out = capsys.readouterr().out
+        assert "battery_charge_percent = 50 %" in out
+
+    @pytest.mark.asyncio
+    async def test_reads_tcx_field_nak(
+        self, fake_connection, resolved_tcx_bike, ephemeral_key, capsys, monkeypatch
+    ):
+        param = cli._TCX_FIELD_NAME_MAP["battery_charge_percent"]
+        param_enum = BikeParameter(param)
+
+        def _factory(address, **kwargs):
+            conn = _FakeConnection(address, **kwargs)
+            conn.tcx_responses[param_enum] = WireMessage(
+                wire_id=0x1234,
+                parameter=param_enum,
+                data=b"",
+                value=None,
+                nak_reason=0x02,
+            )
+            return conn
+
+        monkeypatch.setattr(cli, "SpecializedConnection", _factory)
+
+        args = argparse.Namespace(
+            field="battery_charge_percent",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_read(args)
+
+        out = capsys.readouterr().out
+        assert "rejected" in out
+
+    @pytest.mark.asyncio
+    async def test_read_requires_key_file(self, fake_connection, resolved_tcx_bike):
+        args = argparse.Namespace(
+            field="battery_charge_percent",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        with pytest.raises(cli.KeyRequiredError):
+            await cli._cmd_read(args)
+
+    @pytest.mark.asyncio
+    async def test_tcu1_field_on_tcx_bike_is_rejected(
+        self, fake_connection, resolved_tcx_bike, ephemeral_key, capsys
+    ):
+        args = argparse.Namespace(
+            field="shuttle",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        with pytest.raises(SystemExit):
+            await cli._cmd_read(args)
+        out = capsys.readouterr().out
+        assert "not available on this bike's protocol" in out
+
+
+class TestCmdReadTCU1:
+    @pytest.mark.asyncio
+    async def test_reads_tcu1_field(
+        self, fake_connection, resolved_tcu1_bike, ephemeral_key, capsys, monkeypatch
+    ):
+        def _factory(address, **kwargs):
+            conn = _FakeConnection(address, **kwargs)
+            conn.tcu1_responses[(0x01, 0x00)] = ParsedMessage(
+                sender=0x01,
+                channel=0x00,
+                raw_value=42,
+                converted_value=42,
+                field_name="rider_power",
+                unit="W",
+            )
+            return conn
+
+        monkeypatch.setattr(cli, "SpecializedConnection", _factory)
+
+        args = argparse.Namespace(
+            field="rider_power",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_read(args)
+
+        out = capsys.readouterr().out
+        assert "rider_power = 42 W" in out
+
+    @pytest.mark.asyncio
+    async def test_tcx_only_field_on_tcu1_bike_is_rejected(
+        self, fake_connection, resolved_tcu1_bike, ephemeral_key, capsys
+    ):
+        args = argparse.Namespace(
+            field="max_speed_limit",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        with pytest.raises(SystemExit):
+            await cli._cmd_read(args)
+        out = capsys.readouterr().out
+        assert "not available on this bike's protocol" in out
+
+
+class TestCmdWrite:
+    @pytest.mark.asyncio
+    async def test_writes_tcx_field(
+        self, fake_connection, resolved_tcx_bike, ephemeral_key
+    ):
+        args = argparse.Namespace(
+            field="assist_level",
+            value="2",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_write(args)
+
+        conn = _FakeConnection.instances[-1]
+        assert conn.written_tcx == [(BikeParameter.MOTOR_ACTIVE_TRAVEL_MODE, b"\x02")]
+
+    @pytest.mark.asyncio
+    async def test_writes_tcu1_field(
+        self, fake_connection, resolved_tcu1_bike, ephemeral_key
+    ):
+        args = argparse.Namespace(
+            field="shuttle",
+            value="50",
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_write(args)
+
+        conn = _FakeConnection.instances[-1]
+        assert len(conn.written_tcu1) == 1
+
+
+class TestCmdTelemetry:
+    @pytest.mark.asyncio
+    async def test_telemetry_forwards_generation_bike_info_key(
+        self, resolved_tcx_bike, ephemeral_key, monkeypatch
+    ):
+        captured = {}
+
+        async def _fake_run_telemetry_session(address, **kwargs):
+            captured.update(kwargs)
+            captured["address"] = address
+            from specialized_turbo.models import TelemetrySnapshot
+
+            return TelemetrySnapshot()
+
+        monkeypatch.setattr(cli, "run_telemetry_session", _fake_run_telemetry_session)
+
+        args = argparse.Namespace(
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            duration=0,
+            format="table",
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_telemetry(args)
+
+        assert captured["generation"] == BLEProfile.TCX
+        assert captured["bike_info"].hmi_serial == HMI_SN
+        assert captured["key"].raw == RAW_KEY
+
+
+class TestCmdCapture:
+    @pytest.mark.asyncio
+    async def test_capture_forwards_generation_bike_info_key(
+        self, fake_connection, resolved_tcx_bike, ephemeral_key
+    ):
+        args = argparse.Namespace(
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            duration=0.01,
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_capture(args)
+
+        conn = _FakeConnection.instances[-1]
+        assert conn.generation == BLEProfile.TCX
+        assert conn.bike_info is not None
+        assert conn.bike_info.hmi_serial == HMI_SN
+        assert conn.key is not None
+        assert conn.key.raw == RAW_KEY
+
+    @pytest.mark.asyncio
+    async def test_capture_tcu1_bypasses_key(
+        self, fake_connection, resolved_tcu1_bike, ephemeral_key
+    ):
+        args = argparse.Namespace(
+            address="AA:BB:CC:DD:EE:FF",
+            pin=None,
+            duration=0.01,
+            key_file=None,
+            scan_timeout=5.0,
+        )
+        await cli._cmd_capture(args)
+
+        conn = _FakeConnection.instances[-1]
+        assert conn.generation == BLEProfile.TCU1
+        assert conn.key is None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -12,6 +12,7 @@ would.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import warnings
 from collections.abc import Callable
@@ -20,9 +21,10 @@ from typing import Any, cast
 
 import pytest
 from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.scanner import AdvertisementData
 
 import specialized_turbo.connection as connection_module
-from specialized_turbo.bike_info import BikeInfo
+from specialized_turbo.bike_info import BikeInfo, parse_bike_info
 from specialized_turbo.connection import (
     SpecializedConnection,
     UnsupportedTCXOperationError,
@@ -874,3 +876,402 @@ async def test_no_secret_key_material_in_logs_or_errors(
         await bad_connection.connect()
     assert KEY_RAW.hex() not in str(excinfo.value)
     assert WRONG_KEY_RAW.hex() not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# find_advertisement_by_address
+# ---------------------------------------------------------------------------
+
+
+def _adv(
+    manufacturer_data: dict[int, bytes] | None = None,
+    *,
+    local_name: str | None = None,
+    service_data: dict[str, bytes] | None = None,
+    service_uuids: list[str] | None = None,
+    tx_power: int | None = None,
+    rssi: int = -60,
+    platform_data: tuple[Any, ...] = (),
+) -> AdvertisementData:
+    """Build a real ``bleak`` ``AdvertisementData`` for a test event.
+
+    Using the genuine ``NamedTuple`` (rather than a hand-rolled stand-in)
+    keeps these tests honest about the exact shape
+    ``find_advertisement_by_address``'s merge logic has to handle.
+    """
+    return AdvertisementData(
+        local_name=local_name,
+        manufacturer_data=manufacturer_data or {},
+        service_data=service_data or {},
+        service_uuids=service_uuids or [],
+        tx_power=tx_power,
+        rssi=rssi,
+        platform_data=platform_data,
+    )
+
+
+class _FakeDevice:
+    def __init__(self, address: str, name: str | None = None) -> None:
+        self.address = address
+        self.name = name
+
+
+class _FakeScanner:
+    """Stand-in for ``bleak.BleakScanner``.
+
+    Captures the ``detection_callback`` and, on ``start()``, synchronously
+    replays every ``(device, adv)`` pair queued in ``pending`` -- letting
+    tests simulate advertisements without real BLE hardware.
+    """
+
+    #: Set by each test before constructing a connection/calling the function.
+    pending: list[tuple[Any, Any]] = []
+    #: Every instance constructed, for assertions like "was stop() called".
+    instances: list[_FakeScanner] = []
+
+    def __init__(self, detection_callback: Callable[[Any, Any], None] | None = None):
+        self._cb = detection_callback
+        self.stopped = False
+        _FakeScanner.instances.append(self)
+
+    async def start(self) -> None:
+        for device, adv in _FakeScanner.pending:
+            if self._cb is not None:
+                self._cb(device, adv)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=False)
+def fake_scanner(monkeypatch: pytest.MonkeyPatch) -> type[_FakeScanner]:
+    _FakeScanner.pending = []
+    _FakeScanner.instances = []
+    monkeypatch.setattr(connection_module, "BleakScanner", _FakeScanner)
+    return _FakeScanner
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_returns_matching_device_and_adv(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    device = _FakeDevice("AA:BB:CC:DD:EE:FF", name="SPECIALIZED")
+    adv = _adv({0x0059: b"\x01\x02"})
+    fake_scanner.pending = [(device, adv)]
+
+    result = await connection_module.find_advertisement_by_address(
+        "AA:BB:CC:DD:EE:FF", timeout=0.05
+    )
+
+    assert result is not None
+    found_device, found_adv = result
+    assert found_device is device
+    assert found_adv.manufacturer_data == {0x0059: b"\x01\x02"}
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_is_case_insensitive(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    device = _FakeDevice("aa:bb:cc:dd:ee:ff")
+    adv = _adv({})
+    fake_scanner.pending = [(device, adv)]
+
+    result = await connection_module.find_advertisement_by_address(
+        "AA:BB:CC:DD:EE:FF", timeout=0.05
+    )
+
+    assert result is not None
+    assert result[0] is device
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_ignores_other_devices(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    other = _FakeDevice("11:22:33:44:55:66")
+    fake_scanner.pending = [(other, _adv({}))]
+
+    result = await connection_module.find_advertisement_by_address(
+        "AA:BB:CC:DD:EE:FF", timeout=0.05
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_times_out_when_not_seen(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    fake_scanner.pending = []
+
+    result = await connection_module.find_advertisement_by_address(
+        "AA:BB:CC:DD:EE:FF", timeout=0.05
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_stops_scanner(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    device = _FakeDevice("AA:BB:CC:DD:EE:FF")
+    fake_scanner.pending = [(device, _adv({}))]
+
+    await connection_module.find_advertisement_by_address(
+        "AA:BB:CC:DD:EE:FF", timeout=0.05
+    )
+
+    assert len(_FakeScanner.instances) == 1
+    assert _FakeScanner.instances[0].stopped is True
+
+
+# ---------------------------------------------------------------------------
+# find_advertisement_by_address -- WinRT-style split/multi-event reports
+#
+# Real Windows testers (ha-specialized-turbo#9, comment 4994442091) see
+# Bleak's WinRT backend emit *separate* detection_callback events for the
+# same target address: an initial report carrying only the address (empty
+# name, no manufacturer data), followed later by one with the local name
+# (e.g. "WSBC001057439S") and the Nordic manufacturer bytes. Returning the
+# first (incomplete) event -- as this function used to -- fed
+# parse_bike_info() an empty manufacturer_data dict and it reported no
+# recognized advertisement data even though the bike was seen.
+# ---------------------------------------------------------------------------
+
+#: The real ha-specialized-turbo#9 "Vado 3.0"/2022 bike vector (also used
+#: in tests/test_bike_info.py's TestIssue9RealVector): a complete, 10-byte
+#: Nordic record whose HW version ("B.3.3") is a recognized TCDw2 (TCX2)
+#: category -- so it alone (regardless of name) satisfies both the
+#: is_bike gate and the "complete" Nordic branch.
+_NORDIC_ID = 0x0059
+_APPLE_ID = 0x004C
+_ISSUE9_NAME = "WSBC001057439S"
+_ISSUE9_NORDIC_PAYLOAD = bytes.fromhex("dac8c404423333330601")
+_ISSUE9_APPLE_PAYLOAD = bytes.fromhex("0215545552424f484d4932303137010000005fe033060a")
+
+#: A 10-byte Nordic payload with a deliberately *unrecognized* HW version
+#: ("Z.9.9"), so it does *not* satisfy is_bike on its own -- only combined
+#: with a "SPECIALIZED"-containing name does the merged report become
+#: is_bike/complete. Used to prove completeness genuinely depends on
+#: merging both the name and manufacturer-data events, in either order.
+_UNRECOGNIZED_HW_NORDIC_PAYLOAD = bytes.fromhex("dac8c4045a3939330601")
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_merges_empty_then_named_nordic_report(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """WinRT split: empty/address-only report, then name + Nordic record."""
+    address = "D7:15:00:00:00:01"
+    empty_device = _FakeDevice(address, name=None)
+    named_device = _FakeDevice(address, name=_ISSUE9_NAME)
+    fake_scanner.pending = [
+        (empty_device, _adv({})),
+        (named_device, _adv({_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD})),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(address, timeout=1.0)
+
+    assert result is not None
+    found_device, found_adv = result
+    assert found_device.name == _ISSUE9_NAME
+    assert found_adv.manufacturer_data == {_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD}
+
+    info = parse_bike_info(found_device.name or "", found_adv.manufacturer_data)
+    assert info.is_bike is True
+    assert info.complete is True
+    assert info.bike_name == "COMO2 WSBC001057439S"
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_merges_name_then_nordic_report(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Name-only event, then Nordic-only event (unrecognized HW) -- name first."""
+    address = "D7:15:00:00:00:01"
+    named_device = _FakeDevice(address, name="SPECIALIZED-TEST")
+    unnamed_device = _FakeDevice(address, name=None)
+    fake_scanner.pending = [
+        (named_device, _adv({})),
+        (unnamed_device, _adv({_NORDIC_ID: _UNRECOGNIZED_HW_NORDIC_PAYLOAD})),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(address, timeout=1.0)
+
+    assert result is not None
+    found_device, found_adv = result
+    # The name from the first event must survive the second (nameless) one.
+    assert found_device.name == "SPECIALIZED-TEST"
+    assert found_adv.manufacturer_data == {_NORDIC_ID: _UNRECOGNIZED_HW_NORDIC_PAYLOAD}
+
+    info = parse_bike_info(found_device.name or "", found_adv.manufacturer_data)
+    assert info.is_bike is True
+    assert info.complete is True
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_merges_nordic_then_name_report(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Nordic-only event (unrecognized HW), then name-only event -- reverse order."""
+    address = "D7:15:00:00:00:01"
+    unnamed_device = _FakeDevice(address, name=None)
+    named_device = _FakeDevice(address, name="SPECIALIZED-TEST")
+    fake_scanner.pending = [
+        (unnamed_device, _adv({_NORDIC_ID: _UNRECOGNIZED_HW_NORDIC_PAYLOAD})),
+        (named_device, _adv({})),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(address, timeout=1.0)
+
+    assert result is not None
+    found_device, found_adv = result
+    assert found_device.name == "SPECIALIZED-TEST"
+    assert found_adv.manufacturer_data == {_NORDIC_ID: _UNRECOGNIZED_HW_NORDIC_PAYLOAD}
+
+    info = parse_bike_info(found_device.name or "", found_adv.manufacturer_data)
+    assert info.is_bike is True
+    assert info.complete is True
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_ignores_unrelated_addresses_interleaved(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Unrelated-address events interleaved with the target must never merge in."""
+    address = "D7:15:00:00:00:01"
+    other = _FakeDevice("11:22:33:44:55:66")
+    empty_device = _FakeDevice(address, name=None)
+    named_device = _FakeDevice(address, name=_ISSUE9_NAME)
+    fake_scanner.pending = [
+        (other, _adv({_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD})),
+        (empty_device, _adv({})),
+        (other, _adv({0x1234: b"\xff\xff"})),
+        (named_device, _adv({_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD})),
+        (other, _adv({})),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(address, timeout=1.0)
+
+    assert result is not None
+    found_device, found_adv = result
+    assert found_device.address == address
+    assert found_adv.manufacturer_data == {_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD}
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_apple_only_returns_partial_on_timeout(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Apple-iBeacon-only reports never complete; timeout returns the partial."""
+    address = "D7:15:00:00:00:01"
+    device1 = _FakeDevice(address, name=None)
+    device2 = _FakeDevice(address, name=None)
+    fake_scanner.pending = [
+        (device1, _adv({_APPLE_ID: _ISSUE9_APPLE_PAYLOAD}, rssi=-70)),
+        (device2, _adv({_APPLE_ID: _ISSUE9_APPLE_PAYLOAD}, rssi=-55)),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(
+        address, timeout=0.05
+    )
+
+    assert result is not None
+    found_device, found_adv = result
+    assert found_device.address == address
+    assert found_adv.manufacturer_data == {_APPLE_ID: _ISSUE9_APPLE_PAYLOAD}
+    # Latest RSSI wins even though the report stays incomplete/partial.
+    assert found_adv.rssi == -55
+
+    info = parse_bike_info(found_device.name or "", found_adv.manufacturer_data)
+    assert info.is_bike is False
+    assert info.complete is False
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_merges_service_and_manufacturer_data(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Manufacturer/service data merge key-by-key; service UUIDs are unioned."""
+    address = "D7:15:00:00:00:01"
+    device = _FakeDevice(address, name=None)
+    fake_scanner.pending = [
+        (
+            device,
+            _adv(
+                {_NORDIC_ID: b"\x01\x02"},
+                service_data={"uuid1": b"aa"},
+                service_uuids=["0000180d-0000-1000-8000-00805f9b34fb", "shared-uuid"],
+                tx_power=4,
+            ),
+        ),
+        (
+            device,
+            _adv(
+                {_APPLE_ID: b"\x03\x04"},
+                service_data={"uuid2": b"bb"},
+                service_uuids=["shared-uuid", "another-uuid"],
+            ),
+        ),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(
+        address, timeout=0.05
+    )
+
+    assert result is not None
+    _, found_adv = result
+    assert found_adv.manufacturer_data == {
+        _NORDIC_ID: b"\x01\x02",
+        _APPLE_ID: b"\x03\x04",
+    }
+    assert found_adv.service_data == {"uuid1": b"aa", "uuid2": b"bb"}
+    assert found_adv.service_uuids == [
+        "0000180d-0000-1000-8000-00805f9b34fb",
+        "shared-uuid",
+        "another-uuid",
+    ]
+    # tx_power isn't repeated on the second event -- the earlier non-None
+    # value must survive rather than being blanked out.
+    assert found_adv.tx_power == 4
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_returns_none_when_no_target_seen(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """No event for the target address at all -- still None, never an empty report."""
+    fake_scanner.pending = [
+        (_FakeDevice("11:22:33:44:55:66"), _adv({_NORDIC_ID: _ISSUE9_NORDIC_PAYLOAD})),
+        (_FakeDevice("22:33:44:55:66:77"), _adv({})),
+    ]
+
+    result = await connection_module.find_advertisement_by_address(
+        "D7:15:00:00:00:01", timeout=0.05
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_advertisement_by_address_stops_scanner_on_cancellation(
+    fake_scanner: type[_FakeScanner],
+) -> None:
+    """Cancelling the caller's task must still stop the scanner (no leaks)."""
+    fake_scanner.pending = []  # Nothing arrives -- the call blocks until cancelled.
+
+    task = asyncio.create_task(
+        connection_module.find_advertisement_by_address(
+            "D7:15:00:00:00:01", timeout=30.0
+        )
+    )
+    await asyncio.sleep(0)  # Let the task start and call scanner.start().
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(_FakeScanner.instances) == 1
+    assert _FakeScanner.instances[0].stopped is True


### PR DESCRIPTION
Add HMI-bound key files, split-advertisement aggregation, and mapped TCX CLI commands. Keys must come from an external authorized source.